### PR TITLE
Add possibility to deploy the runtime with ingress disabled without deploying tunnel client

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Added support for custom CA
+      description: Allow disabling ingress without deploying tunnel-client.
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -32,3 +32,4 @@ dependencies:
   repository: https://chartmuseum.codefresh.io/codefresh-tunnel-client
   version: "0.1.12"
   alias: tunnel-client
+  condition: tunnel-client.enabled

--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -139,7 +139,7 @@ A Helm chart for Codefresh gitops runtime
 | global.codefresh.userToken | object | `{"secretKeyRef":{},"token":""}` | User token. Used for runtime registration against the patform. One of token (for plain text value) or secretKeyRef must be provided. |
 | global.codefresh.userToken.secretKeyRef | object | `{}` | User token that references an existing secret containing the token. |
 | global.codefresh.userToken.token | string | `""` | User token in plain text. The chart creates and manages the secret for this token. |
-| global.runtime | object | `{"cluster":"https://kubernetes.default.svc","eventBus":{"nats":{"native":{"auth":"token","containerTemplate":{"resources":{"limits":{"cpu":"500m","ephemeral-storage":"2Gi","memory":"4Gi"},"requests":{"cpu":"200m","ephemeral-storage":"2Gi","memory":"1Gi"}}},"maxPayload":"4MB","replicas":3}}},"eventBusName":"codefresh-eventbus","gitCredentials":{"password":{"secretKeyRef":{},"value":null},"username":"username"},"ingress":{"annotations":{},"className":"nginx","enabled":false,"hosts":[],"protocol":"https","tls":[]},"name":null}` | Runtime level settings |
+| global.runtime | object | `{"cluster":"https://kubernetes.default.svc","eventBus":{"nats":{"native":{"auth":"token","containerTemplate":{"resources":{"limits":{"cpu":"500m","ephemeral-storage":"2Gi","memory":"4Gi"},"requests":{"cpu":"200m","ephemeral-storage":"2Gi","memory":"1Gi"}}},"maxPayload":"4MB","replicas":3}}},"eventBusName":"codefresh-eventbus","gitCredentials":{"password":{"secretKeyRef":{},"value":null},"username":"username"},"ingress":{"annotations":{},"className":"nginx","enabled":false,"hosts":[],"protocol":"https","tls":[]},"ingressUrl":"","name":null}` | Runtime level settings |
 | global.runtime.cluster | string | `"https://kubernetes.default.svc"` | Runtime cluster. Should not be changed. |
 | global.runtime.eventBus | object | `{"nats":{"native":{"auth":"token","containerTemplate":{"resources":{"limits":{"cpu":"500m","ephemeral-storage":"2Gi","memory":"4Gi"},"requests":{"cpu":"200m","ephemeral-storage":"2Gi","memory":"1Gi"}}},"maxPayload":"4MB","replicas":3}}}` | EventBus spec |
 | global.runtime.eventBusName | string | `"codefresh-eventbus"` | Eventbus name |
@@ -152,6 +152,7 @@ A Helm chart for Codefresh gitops runtime
 | global.runtime.ingress.enabled | bool | `false` | Defines if ingress-based access mode is enabled for runtime. To use tunnel-based (ingressless) access mode, set to false. |
 | global.runtime.ingress.hosts | list | `[]` | Hosts for runtime ingress. Note that Codefresh platform will always use the first host in the list to access the runtime. |
 | global.runtime.ingress.protocol | string | `"https"` | The protocol that Codefresh platform will use to access the runtime ingress. Can be http or https. |
+| global.runtime.ingressUrl | string | `""` | Explicit url for runtime ingress. Provide this value only if you don't want the chart to create and ingress (global.runtime.ingress.enabled=false) and tunnel-client is not used (tunnel-client.enabled=false) |
 | global.runtime.name | string | `nil` | Runtime name. Must be identical to the namepsace in which it is intalled and must be unique per platform account. |
 | installer | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"quay.io/codefresh/gitops-runtime-installer","tag":""}}` | Runtime installer used for running hooks and checks on the release |
 | internal-router.affinity | object | `{}` |  |
@@ -180,7 +181,8 @@ A Helm chart for Codefresh gitops runtime
 | internal-router.serviceAccount.name | string | `""` |  |
 | internal-router.tolerations | list | `[]` |  |
 | sealed-secrets | object | `{"fullnameOverride":"sealed-secrets-controller","image":{"registry":"quay.io","repository":"codefresh/sealed-secrets-controller","tag":"v0.19.4"},"keyrenewperiod":"720h","resources":{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}}` | --------------------------------------------------------------------------------------------------------------------- |
-| tunnel-client | object | `{"libraryMode":true,"tunnelServer":{"host":"register-tunnels.cf-cd.com","subdomainHost":"tunnels.cf-cd.com"}}` | Tunnel based runtime. Only relevant when runtime.ingress.enabled = false |
+| tunnel-client | object | `{"enabled":true,"libraryMode":true,"tunnelServer":{"host":"register-tunnels.cf-cd.com","subdomainHost":"tunnels.cf-cd.com"}}` | Tunnel based runtime. Not supported for on-prem platform. In on-prem use ingress based runtimes. |
+| tunnel-client.enabled | bool | `true` | Will only be used if global.runtime.ingress.enabled = false |
 | tunnel-client.libraryMode | bool | `true` | Do not change this value! Breaks chart logic |
 
 ----------------------------------------------

--- a/charts/gitops-runtime/templates/_helpers.tpl
+++ b/charts/gitops-runtime/templates/_helpers.tpl
@@ -177,19 +177,32 @@ valueFrom:
 Get ingress url for both tunnel based and ingress based runtimes
 */}}
 {{- define "codefresh-gitops-runtime.ingress-url"}}
+  {{- $supportedProtocols := list "http" "https" }}
     {{- if .Values.global.runtime.ingress.enabled }}
-      {{- $supportedProtocols := list "http" "https" }}
       {{- if has .Values.global.runtime.ingress.protocol $supportedProtocols }}
         {{- printf "%s://%s" .Values.global.runtime.ingress.protocol  (index .Values.global.runtime.ingress.hosts 0)}}
       {{- else }}
           {{ fail (printf "ERROR: Unsupported protocol %s for ingress. Only http and https supported" .Values.global.runtime.ingress.protocol)}}
       {{- end }}
-    {{- else }}
+    {{/* If tunnel client is enabled - ingress url is <accoundId>-<runtimename>.<tunnel-subdomain> */}}
+    {{- else if index .Values "tunnel-client" "enabled" }}
       {{- $accoundId := required "codefresh.accountId is required" .Values.global.codefresh.accountId }}
       {{- $runtimeName := required "runtime.name is required" .Values.global.runtime.name }}
       {{- $tunnelPrefix := printf "%s-%s" .Values.global.codefresh.accountId .Values.global.runtime.name }}
       {{- $tunnelHost := index (get .Values "tunnel-client") "tunnelServer" "subdomainHost"}}
       {{- printf "https://%s.%s" $tunnelPrefix $tunnelHost }}
+    {{- else }}
+    {{/* If ingress is disabled and tunnel-client is disabled, the ingressHost must be explicitly defined in the values*/}}
+      {{- if .Values.global.runtime.ingressUrl }}
+        {{- $urlObject = urlParse .Values.global.runtime.ingressUrl }}
+          {{- if has $urlObject.scheme $supportedProtocols }}
+            {{- print .Values.global.runtime.ingressUrl }}
+          {{- else }}
+            {{- fail "ERROR: Only http and https are supported for global.runtime.ingressUrl"}}
+          {{- end }}
+      {{- else }}
+        {{- fail "ERROR: When global.runtime.ingress.enabled is false and tunnel-client.enabled is false -  global.runtime.ingressUrl must be provided" }}
+      {{- end }}
     {{- end }}
 {{- end }}
 
@@ -216,7 +229,7 @@ Output comma separated list of installed runtime components
     {{- $comptList = append $comptList $workflowReporter}}
     {{- $comptList = append $comptList $argoWorkflows }}
   {{- end }}
-  {{- if not .Values.global.runtime.ingress.enabled }}
+  {{- if not (and .Values.global.runtime.ingress.enabled (index .Values "tunnel-client" "enabled")) }}
     {{- $tunnelClient := dict "name" "codefresh-tunnel-client" "version" (get .Subcharts "tunnel-client").Chart.AppVersion }}
     {{- $comptList = append $comptList $tunnelClient }}
   {{- end }}

--- a/charts/gitops-runtime/templates/_helpers.tpl
+++ b/charts/gitops-runtime/templates/_helpers.tpl
@@ -183,16 +183,15 @@ Get ingress url for both tunnel based and ingress based runtimes
       {{- end }}
     {{/* If tunnel client is enabled - ingress url is <accoundId>-<runtimename>.<tunnel-subdomain> */}}
     {{- else if index .Values "tunnel-client" "enabled" }}
-      {{- $accoundId := required "codefresh.accountId is required" .Values.global.codefresh.accountId }}
-      {{- $runtimeName := required "runtime.name is required" .Values.global.runtime.name }}
+      {{- $accoundId := required "global.codefresh.accountId is required for tunnel based runtime" .Values.global.codefresh.accountId }}
+      {{- $runtimeName := required "global.runtime.name is required for tunnel based runtime" .Values.global.runtime.name }}
       {{- $tunnelPrefix := printf "%s-%s" .Values.global.codefresh.accountId .Values.global.runtime.name }}
       {{- $tunnelHost := index (get .Values "tunnel-client") "tunnelServer" "subdomainHost"}}
       {{- printf "https://%s.%s" $tunnelPrefix $tunnelHost }}
     {{- else }}
     {{/* If ingress is disabled and tunnel-client is disabled, the ingressHost must be explicitly defined in the values*/}}
       {{- if .Values.global.runtime.ingressUrl }}
-        {{- $urlObject = urlParse .Values.global.runtime.ingressUrl }}
-          {{- if has $urlObject.scheme $supportedProtocols }}
+          {{- if or (hasPrefix "http" .Values.global.runtime.ingressUrl) (hasPrefix "https" .Values.global.runtime.ingressUrl)}}
             {{- print .Values.global.runtime.ingressUrl }}
           {{- else }}
             {{- fail "ERROR: Only http and https are supported for global.runtime.ingressUrl"}}
@@ -226,7 +225,7 @@ Output comma separated list of installed runtime components
     {{- $comptList = append $comptList $workflowReporter}}
     {{- $comptList = append $comptList $argoWorkflows }}
   {{- end }}
-  {{- if not (and .Values.global.runtime.ingress.enabled (index .Values "tunnel-client" "enabled")) }}
+  {{- if and ( not .Values.global.runtime.ingress.enabled) (index .Values "tunnel-client" "enabled") }}
     {{- $tunnelClient := dict "name" "codefresh-tunnel-client" "version" (get .Subcharts "tunnel-client").Chart.AppVersion }}
     {{- $comptList = append $comptList $tunnelClient }}
   {{- end }}

--- a/charts/gitops-runtime/templates/tunnel-client.yaml
+++ b/charts/gitops-runtime/templates/tunnel-client.yaml
@@ -4,7 +4,7 @@ to intruduce the subdomainPrefix to the tunnel.
 Since the prefix is comprised of <accoundId>-<runtime name>, we can tempalate it and thus 
 reduce complexity of installation and number or mandatory values to provide for the installation to work.
  */}}
-{{- if not .Values.global.runtime.ingress.enabled}}
+{{- if and ( not .Values.global.runtime.ingress.enabled) (index .Values "tunnel-client" "enabled") }}
 {{ $tunnelClientContext := (index .Subcharts "tunnel-client")}}
 {{ $accoundId := required "codefresh.accountId is required" .Values.global.codefresh.accountId }}
 {{ $runtimeName := required "runtime.name is required" .Values.global.runtime.name }}

--- a/charts/gitops-runtime/tests/ingress_test.yaml
+++ b/charts/gitops-runtime/tests/ingress_test.yaml
@@ -1,0 +1,118 @@
+suite: misc tests on app-proxy templates generation
+templates:
+  - templates/ingress.yaml
+  - templates/tunnel-client.yaml
+  - templates/codefresh-cm.yaml
+tests:
+- it: no ingress when tunnel runtime is configured
+  template: templates/ingress.yaml
+  values:
+  - ./values/mandatory-values.yaml
+  asserts:
+    - hasDocuments:
+        count: 0
+
+- it: no tunnel when ingress is configured
+  template: templates/tunnel-client.yaml
+  values:
+  - ./values/mandatory-values-ingress.yaml
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: tunnel client rendering fails when accountId not provided
+  template: templates/tunnel-client.yaml
+  values:
+  - ./values/mandatory-values.yaml
+  set:
+    global.codefresh.accountId: ""
+  asserts:
+    - failedTemplate:
+        errorMessage: codefresh.accountId is required
+
+- it: when both tunnel-client and ingress are disabled fail rendering if ingressUrl is not provided
+  template: templates/codefresh-cm.yaml
+  values:
+  - ./values/mandatory-values.yaml
+  set:
+    global.runtime.ingress.enabled: false
+    tunnel-client.enabled: false
+  asserts:
+    - failedTemplate:
+        errorMessage: When global.runtime.ingress.enabled is false and tunnel-client.enabled is false -  global.runtime.ingressUrl must be provided
+
+- it: fail on ingressUrl that is not http or https
+  template: templates/codefresh-cm.yaml
+  values:
+  - ./values/mandatory-values.yaml
+  set:
+    global.runtime.ingress.enabled: false
+    tunnel-client.enabled: false
+    global.runtime.ingressUrl: test.test.fail
+  asserts:
+    - failedTemplate:
+        errorMessage: Only http and https are supported for global.runtime.ingressUrl
+
+- it: codefresh-cm ingressHost is set correctly when ingress enabled
+  template: templates/codefresh-cm.yaml
+  values:
+  - ./values/mandatory-values-ingress.yaml
+  set:
+    global.runtime.ingress.enabled: true
+    global.runtime.ingress.hosts: [test.example.com]
+    global.runtime.ingress.protocol: https
+  asserts:
+  - equal:
+      path: data.ingressHost
+      value:  https://test.example.com
+
+- it: codefresh-cm ingressHost is set correctly when tunnel based
+  template: templates/codefresh-cm.yaml
+  values:
+  - ./values/mandatory-values.yaml
+  set:
+    global.runtime.ingress.enabled: false
+    global.codefresh.accountId: aabbccdd
+    global.runtime.name: test
+    tunnel-client.enabled: true
+    tunnel-client.tunnelServer.subdomainHost: my-tunnels.com
+  asserts:
+  - equal:
+      path: data.ingressHost
+      value:  https://aabbccdd-test.my-tunnels.com
+
+- it: codefresh-cm ingressHost is set correctly when ingressUrl is used (ingress and tunnel both disabled)
+  template: templates/codefresh-cm.yaml
+  values:
+  - ./values/mandatory-values.yaml
+  set:
+    global.runtime.ingress.enabled: false
+    tunnel-client.enabled: false
+    global.runtime.ingressUrl: https://test.test.test
+  asserts:
+  - equal:
+      path: data.ingressHost
+      value:  https://test.test.test
+
+- it: ingress correctly rendered
+  template: templates/ingress.yaml
+  set:
+    global.runtime.ingress.enabled: true
+    global.runtime.ingress.hosts: [test.example.com]
+    global.runtime.ingress.protocol: https
+    global.runtime.ingress.className: myclass
+    global.runtime.ingress.tls: [{secretName: blah, hosts: [test.example.com]}]
+  values:
+  - ./values/mandatory-values-ingress.yaml
+  asserts:
+  - equal:
+      path: spec.ingressClassName
+      value:  myclass
+  - equal:
+      path: spec.rules[0].host
+      value: test.example.com
+  - equal:
+      path: spec.tls
+      value:
+      - hosts:
+        - "test.example.com"
+        secretName: blah

--- a/charts/gitops-runtime/tests/values/mandatory-values.yaml
+++ b/charts/gitops-runtime/tests/values/mandatory-values.yaml
@@ -6,9 +6,5 @@ global:
 
   runtime:
     name: test-runtime1
-
     ingress:
       enabled: false
-
-argo-rollouts:
-  enabled: true

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -31,6 +31,10 @@ global:
       # -- Hosts for runtime ingress. Note that Codefresh platform will always use the first host in the list to access the runtime.
       hosts: []
 
+    # -- Explicit url for runtime ingress. Provide this value only if you don't want the chart to create and ingress (global.runtime.ingress.enabled=false) and tunnel-client is not used (tunnel-client.enabled=false)
+    ingressUrl: ""
+    
+
     # -- Git credentials runtime. Runtime is not fully functional without those credentials.
     # If not provided through the installation, they must be provided through the Codefresh UI.
     gitCredentials:
@@ -229,8 +233,10 @@ internal-router:
 #-----------------------------------------------------------------------------------------------------------------------
 # tunnel client
 #-----------------------------------------------------------------------------------------------------------------------
-# -- Tunnel based runtime. Only relevant when runtime.ingress.enabled = false
+# -- Tunnel based runtime. Not supported for on-prem platform. In on-prem use ingress based runtimes.
 tunnel-client:
+  # -- Will only be used if global.runtime.ingress.enabled = false
+  enabled: true
   # -- Do not change this value! Breaks chart logic
   libraryMode: true
   tunnelServer:


### PR DESCRIPTION
In such a case global.runtime.ingressUrl becomes mandatory.