### PR TITLE
feat: update env-vars helper template

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -16,6 +16,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Update `argo-events` to 2.0.5-1-cf-init
+    - kind: changed
+      description: Update env-vars helper template
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm

--- a/charts/gitops-runtime/templates/_components/_common_helpers.yaml
+++ b/charts/gitops-runtime/templates/_components/_common_helpers.yaml
@@ -9,14 +9,14 @@ env: []
   {{- else -}}
 env:
     {{- range $name, $val := . }}
-      {{- if kindIs "string" $val}}
+      {{- if or (kindIs "string" $val) (kindIs "bool" $val) (kindIs "int" $val) (kindIs "float64" $val) }}
 - name: {{ $name }}
-  value: {{ $val }}
+  value: {{ $val | quote }}
       {{- else if kindIs "map" $val}}
         {{- if hasKey $val "valueFrom" }}
           {{- if or (hasKey $val.valueFrom "secretKeyRef") (hasKey $val.valueFrom "configMapKeyRef") (hasKey $val.valueFrom "fieldRef") }}
 - name: {{ $name }}
-{{- $val | toYaml | nindent 2}}        
+{{- $val | toYaml | nindent 2}}
           {{- else}}
             {{ fail "ERROR: Only secretKeyRef/configMapKeyRef/fieldRef are supported for valueFrom block for environment variables" }}
           {{- end}}

--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/environment-variables/_main-container.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/environment-variables/_main-container.yaml
@@ -61,23 +61,23 @@ GRAPHQL_PLAYGROUND:
       name: cap-app-proxy-cm
       key: graphqlPlayground
       optional: true
-INGRESS_CLASS_NAME: 
+INGRESS_CLASS_NAME:
   valueFrom:
     configMapKeyRef:
       name: codefresh-cm
       key: ingressClassName
-INGRESS_CONTROLLER: 
+INGRESS_CONTROLLER:
   valueFrom:
     configMapKeyRef:
       name: codefresh-cm
       key: ingressController
-INGRESS_HOST: 
+INGRESS_HOST:
   valueFrom:
     configMapKeyRef:
       name: codefresh-cm
       key: ingressHost
 INSTALLATION_TYPE: HELM
-MANAGED: '"false"'
+MANAGED: false
 NAMESPACE:
   valueFrom:
     fieldRef:

--- a/charts/gitops-runtime/tests/app-proxy-misc_test.yaml
+++ b/charts/gitops-runtime/tests/app-proxy-misc_test.yaml
@@ -14,7 +14,7 @@ tests:
       path: spec.template.spec.containers[0].env
       content:
         name: PORT
-        value: 8787
+        value: "8787"
 - it: adding environment variables on main container
   template: 'app-proxy/deployment.yaml'
   values:
@@ -103,7 +103,7 @@ tests:
   values:
   - ./values/mandatory-values.yaml
   set:
-    app-proxy.nodeSelector: 
+    app-proxy.nodeSelector:
       test.io/node: "test"
   asserts:
   - equal:
@@ -135,7 +135,7 @@ tests:
   values:
   - ./values/mandatory-values.yaml
   set:
-    app-proxy.affinity: 
+    app-proxy.affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
@@ -218,4 +218,4 @@ tests:
       path: spec.template.spec.initContainers[0].volumeMounts
       content:
         name: my-secret
-        mountPath: /my-secret 
+        mountPath: /my-secret


### PR DESCRIPTION
To allow passing env vars like

```
app-proxy:
  env:
    NODE_TLS_REJECT_UNAUTHORIZED: 0
```