### PR TITLE
build: update `app-proxy` to 1.2606.1

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.38
+appVersion: 0.1.39
 description: A Helm chart for Codefresh gitops runtime
 name: gitops-runtime
 version: 0.4.2
@@ -17,7 +17,9 @@ annotations:
     - kind: changed
       description: Update argo-cd chart to 5.51.6-4-cap-2.9-2023.12.28-a52e719a5
     - kind: changed
-      description: Update app-proxy to 1.2593.0
+      description: Update app-proxy to 1.2606.1
+    - kind: fixed
+      description: Fix runtime components log
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm

--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -1,5 +1,5 @@
 ## Codefresh gitops runtime
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.1.38](https://img.shields.io/badge/AppVersion-0.1.38-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.1.39](https://img.shields.io/badge/AppVersion-0.1.39-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -100,14 +100,14 @@ sealed-secrets:
 | app-proxy.image-enrichment.serviceAccount.name | string | `"codefresh-image-enrichment-sa"` | Name of the service account to create or the name of the existing one to use |
 | app-proxy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | app-proxy.image.repository | string | `"quay.io/codefresh/cap-app-proxy"` |  |
-| app-proxy.image.tag | string | `"1.2593.0"` |  |
+| app-proxy.image.tag | string | `"1.2606.1"` |  |
 | app-proxy.imagePullSecrets | list | `[]` |  |
 | app-proxy.initContainer.command[0] | string | `"./init.sh"` |  |
 | app-proxy.initContainer.env | object | `{}` |  |
 | app-proxy.initContainer.extraVolumeMounts | list | `[]` | Extra volume mounts for init container |
 | app-proxy.initContainer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | app-proxy.initContainer.image.repository | string | `"quay.io/codefresh/cap-app-proxy-init"` |  |
-| app-proxy.initContainer.image.tag | string | `"1.2593.0"` |  |
+| app-proxy.initContainer.image.tag | string | `"1.2606.1"` |  |
 | app-proxy.initContainer.resources.limits.cpu | string | `"1"` |  |
 | app-proxy.initContainer.resources.limits.memory | string | `"512Mi"` |  |
 | app-proxy.initContainer.resources.requests.cpu | string | `"0.2"` |  |

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -418,7 +418,7 @@ app-proxy:
           tag: 1.1.10-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.2593.0
+    tag: 1.2606.1
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -426,7 +426,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.2593.0
+      tag: 1.2606.1
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
This updates `app-proxy` to 1.2606.1, fixing logs for Runtime components.

Fixes #CR-20634