### PR TITLE
bump gitops-operator to `1.0.3`

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -45,6 +45,6 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 1.0.2
+  version: 1.0.3
   alias: gitops-operator
   condition: gitops-operator.enabled

--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -1,5 +1,5 @@
 ## Codefresh gitops runtime
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![AppVersion: 0.1.39](https://img.shields.io/badge/AppVersion-0.1.39-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![AppVersion: 0.1.40](https://img.shields.io/badge/AppVersion-0.1.40-informational?style=flat-square)
 
 ## Prerequisites
 


### PR DESCRIPTION
## What
bump gitops-operator to `1.0.3`

## Why
fix env vars in template

## Notes
<!-- Add any notes here -->