### PR TITLE
bump gitops-operator to `1.0.4`

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -45,6 +45,6 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 1.0.3
+  version: 1.0.4
   alias: gitops-operator
   condition: gitops-operator.enabled


### PR DESCRIPTION
## What
bump gitops-operator to `1.0.4`

## Why
removes productSelector and priority fields

## Notes
<!-- Add any notes here -->