### PR TITLE
update argo-cd to 5.53.12-7-cap-2.9-2024.3.12-b23aa3fb6

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -13,11 +13,13 @@ maintainers:
     url: https://codefresh-io.github.io/
 annotations:
   artifacthub.io/alternativeName: "codefresh-gitops-runtime"
-  artifacthub.io/changes: ''
+  artifacthub.io/changes: |
+    - kind: changed
+      description: "jsonPath to application versions uses format with $ sign for root element"
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
-  version: 5.53.12-6-cap-2.9-2024.3.5-80c3e7225
+  version: 5.53.12-7-cap-2.9-2024.3.12-b23aa3fb6
 - name: argo-events
   repository: https://codefresh-io.github.io/argo-helm
   version: 2.0.9-1-cap-CR-19893


### PR DESCRIPTION
## What
jsonPath to application versions uses format with $ sign for root element
## Why
Align with promotion
## Notes
<!-- Add any notes here -->