### PR TITLE
updated argo-cd helm chart to `6.7.18-1-cap-2.10-2024.3.29-1dcc54e29`

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -20,10 +20,12 @@ annotations:
       description: "update codefresh-gitops-operator to 0.1.0-alpha.12"
     - kind: changed
       description: "update cap-app-proxy to 1.2816.0"
+    - kind: fixed
+      description: "update argo-cd helm chart to 6.7.18-1-cap-2.10-2024.3.29-1dcc54e29 (fix notification configuration overrides)"
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
-  version: 6.7.18-cap-2.10-2024.3.29-1dcc54e29
+  version: 6.7.18-1-cap-2.10-2024.3.29-1dcc54e29
 - name: argo-events
   repository: https://codefresh-io.github.io/argo-helm
   version: 2.0.9-1-cap-CR-19893

--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -146,6 +146,14 @@ sealed-secrets:
 | app-proxy.tolerations | list | `[]` |  |
 | argo-cd.applicationVersioning.enabled | bool | `true` | Enable application versioning |
 | argo-cd.applicationVersioning.useApplicationConfiguration | bool | `true` | Extract application version based on ApplicationConfiguration CRD |
+| argo-cd.codefresh.promotions.notifications.notifiers."service.webhook.cf-promotion-app-revision-changed-notifier" | string | `"url: http://gitops-operator:8082/app-revision-changed\nheaders:\n- name: Content-Type\n  value: application/json\n"` |  |
+| argo-cd.codefresh.promotions.notifications.subscriptions[0].recipients[0] | string | `"cf-promotion-app-revision-changed-notifier"` |  |
+| argo-cd.codefresh.promotions.notifications.subscriptions[0].triggers[0] | string | `"cf-promotion-on-deployed-trigger"` |  |
+| argo-cd.codefresh.promotions.notifications.subscriptions[1].recipients[0] | string | `"cf-promotion-app-revision-changed-notifier"` |  |
+| argo-cd.codefresh.promotions.notifications.subscriptions[1].triggers[0] | string | `"cf-promotion-on-out-of-sync-trigger"` |  |
+| argo-cd.codefresh.promotions.notifications.templates."template.cf-promotion-app-revision-changed-template" | string | `"webhook:\n  cf-promotion-app-revision-changed-notifier:\n    method: POST\n    body: |\n      {\n        \"APP_NAMESPACE\": {{ .app.metadata.namespace | quote }},\n        \"APP_NAME\": {{ .app.metadata.name | quote }},\n        \"REPO_URL\": {{ call .repo.RepoURLToHTTPS .app.spec.source.repoURL | quote }},\n        \"BRANCH\": {{ .app.spec.source.targetRevision | quote }},\n        \"PATH\": {{ .app.spec.source.path | quote }},\n        \"PREV_COMMIT_SHA\": {{ (index .app.status.history (sub (len .app.status.history) 2)).revision | quote }},\n        \"CURRENT_COMMIT_SHA\": {{ .app.status.operationState.syncResult.revision | quote }}\n      }\n"` |  |
+| argo-cd.codefresh.promotions.notifications.triggers."trigger.cf-promotion-on-deployed-trigger" | string | `"- description: Application is synced and healthy. Triggered once per commit.\n  when: get(app.spec.syncPolicy, \"automated\") != nil && app.status.sync.status == \"Synced\" && app.status.health.status == \"Healthy\" && app.status.operationState.syncResult.revision != nil\n  oncePer: app.status.operationState.syncResult.revision\n  send:\n  - cf-promotion-app-revision-changed-template\n"` |  |
+| argo-cd.codefresh.promotions.notifications.triggers."trigger.cf-promotion-on-out-of-sync-trigger" | string | `"- description: Application is out of sync (when autoHeal is off). Triggered once per commit.\n  when: get(app.spec.syncPolicy, \"automated\") == nil && app.status.sync.status == \"OutOfSync\" && app.status.operationState.syncResult.revision != nil\n  oncePer: app.status.operationState.syncResult.revision\n  send:\n  - cf-promotion-app-revision-changed-template\n"` |  |
 | argo-cd.configs.cm."accounts.admin" | string | `"apiKey,login"` |  |
 | argo-cd.configs.cm."application.resourceTrackingMethod" | string | `"annotation+label"` |  |
 | argo-cd.configs.cm."timeout.reconciliation" | string | `"20s"` |  |
@@ -156,16 +164,7 @@ sealed-secrets:
 | argo-cd.eventReporter.replicas | int | `3` | Amount of shards to handle applications events |
 | argo-cd.eventReporter.version | string | `"v2"` | Switches between old and new reporter version. Possible values: v1, v2. For v2 `argo-cd.eventReporter.enabled=true` is required |
 | argo-cd.fullnameOverride | string | `"argo-cd"` |  |
-| argo-cd.notifications.bots.slack | object | `{}` |  |
 | argo-cd.notifications.enabled | bool | `true` |  |
-| argo-cd.notifications.notifiers."service.webhook.cf-promotion-app-revision-changed-notifier" | string | `"url: http://gitops-operator:8082/app-revision-changed\nheaders:\n- name: Content-Type\n  value: application/json\n"` |  |
-| argo-cd.notifications.subscriptions[0].recipients[0] | string | `"cf-promotion-app-revision-changed-notifier"` |  |
-| argo-cd.notifications.subscriptions[0].triggers[0] | string | `"cf-promotion-on-deployed-trigger"` |  |
-| argo-cd.notifications.subscriptions[1].recipients[0] | string | `"cf-promotion-app-revision-changed-notifier"` |  |
-| argo-cd.notifications.subscriptions[1].triggers[0] | string | `"cf-promotion-on-out-of-sync-trigger"` |  |
-| argo-cd.notifications.templates."template.cf-promotion-app-revision-changed-template" | string | `"webhook:\n  cf-promotion-app-revision-changed-notifier:\n    method: POST\n    body: |\n      {\n        \"APP_NAMESPACE\": {{ .app.metadata.namespace | quote }},\n        \"APP_NAME\": {{ .app.metadata.name | quote }},\n        \"REPO_URL\": {{ call .repo.RepoURLToHTTPS .app.spec.source.repoURL | quote }},\n        \"BRANCH\": {{ .app.spec.source.targetRevision | quote }},\n        \"PATH\": {{ .app.spec.source.path | quote }},\n        \"PREV_COMMIT_SHA\": {{ (index .app.status.history (sub (len .app.status.history) 2)).revision | quote }},\n        \"CURRENT_COMMIT_SHA\": {{ .app.status.operationState.syncResult.revision | quote }}\n      }\n"` |  |
-| argo-cd.notifications.triggers."trigger.cf-promotion-on-deployed-trigger" | string | `"- description: Application is synced and healthy. Triggered once per commit.\n  when: get(app.spec.syncPolicy, \"automated\") != nil && app.status.sync.status == \"Synced\" && app.status.health.status == \"Healthy\" && app.status.operationState.syncResult.revision != nil\n  oncePer: app.status.operationState.syncResult.revision\n  send:\n  - cf-promotion-app-revision-changed-template\n"` |  |
-| argo-cd.notifications.triggers."trigger.cf-promotion-on-out-of-sync-trigger" | string | `"- description: Application is out of sync (when autoHeal is off). Triggered once per commit.\n  when: get(app.spec.syncPolicy, \"automated\") == nil && app.status.sync.status == \"OutOfSync\" && app.status.operationState.syncResult.revision != nil\n  oncePer: app.status.operationState.syncResult.revision\n  send:\n  - cf-promotion-app-revision-changed-template\n"` |  |
 | argo-events.crds.install | bool | `false` |  |
 | argo-events.fullnameOverride | string | `"argo-events"` |  |
 | argo-rollouts.controller.replicas | int | `1` |  |

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -168,55 +168,55 @@ argo-cd:
   notifications:
     enabled: true
 
-    bots:
-      slack: {}
+  codefresh:
+    promotions:
+      notifications:
+        notifiers:
+          service.webhook.cf-promotion-app-revision-changed-notifier: |
+            url: http://gitops-operator:8082/app-revision-changed
+            headers:
+            - name: Content-Type
+              value: application/json
 
-    notifiers:
-      service.webhook.cf-promotion-app-revision-changed-notifier: |
-        url: http://gitops-operator:8082/app-revision-changed
-        headers:
-        - name: Content-Type
-          value: application/json
+        subscriptions:
+          - triggers:
+              - cf-promotion-on-deployed-trigger
+            recipients:
+              - cf-promotion-app-revision-changed-notifier
+          - triggers:
+              - cf-promotion-on-out-of-sync-trigger
+            recipients:
+              - cf-promotion-app-revision-changed-notifier
 
-    subscriptions:
-      - triggers:
-          - cf-promotion-on-deployed-trigger
-        recipients:
-          - cf-promotion-app-revision-changed-notifier
-      - triggers:
-          - cf-promotion-on-out-of-sync-trigger
-        recipients:
-          - cf-promotion-app-revision-changed-notifier
+        templates:
+          template.cf-promotion-app-revision-changed-template: |
+            webhook:
+              cf-promotion-app-revision-changed-notifier:
+                method: POST
+                body: |
+                  {
+                    "APP_NAMESPACE": {{ .app.metadata.namespace | quote }},
+                    "APP_NAME": {{ .app.metadata.name | quote }},
+                    "REPO_URL": {{ call .repo.RepoURLToHTTPS .app.spec.source.repoURL | quote }},
+                    "BRANCH": {{ .app.spec.source.targetRevision | quote }},
+                    "PATH": {{ .app.spec.source.path | quote }},
+                    "PREV_COMMIT_SHA": {{ (index .app.status.history (sub (len .app.status.history) 2)).revision | quote }},
+                    "CURRENT_COMMIT_SHA": {{ .app.status.operationState.syncResult.revision | quote }}
+                  }
 
-    templates:
-      template.cf-promotion-app-revision-changed-template: |
-        webhook:
-          cf-promotion-app-revision-changed-notifier:
-            method: POST
-            body: |
-              {
-                "APP_NAMESPACE": {{ .app.metadata.namespace | quote }},
-                "APP_NAME": {{ .app.metadata.name | quote }},
-                "REPO_URL": {{ call .repo.RepoURLToHTTPS .app.spec.source.repoURL | quote }},
-                "BRANCH": {{ .app.spec.source.targetRevision | quote }},
-                "PATH": {{ .app.spec.source.path | quote }},
-                "PREV_COMMIT_SHA": {{ (index .app.status.history (sub (len .app.status.history) 2)).revision | quote }},
-                "CURRENT_COMMIT_SHA": {{ .app.status.operationState.syncResult.revision | quote }}
-              }
-
-    triggers:
-      trigger.cf-promotion-on-deployed-trigger: |
-        - description: Application is synced and healthy. Triggered once per commit.
-          when: get(app.spec.syncPolicy, "automated") != nil && app.status.sync.status == "Synced" && app.status.health.status == "Healthy" && app.status.operationState.syncResult.revision != nil
-          oncePer: app.status.operationState.syncResult.revision
-          send:
-          - cf-promotion-app-revision-changed-template
-      trigger.cf-promotion-on-out-of-sync-trigger: |
-        - description: Application is out of sync (when autoHeal is off). Triggered once per commit.
-          when: get(app.spec.syncPolicy, "automated") == nil && app.status.sync.status == "OutOfSync" && app.status.operationState.syncResult.revision != nil
-          oncePer: app.status.operationState.syncResult.revision
-          send:
-          - cf-promotion-app-revision-changed-template
+        triggers:
+          trigger.cf-promotion-on-deployed-trigger: |
+            - description: Application is synced and healthy. Triggered once per commit.
+              when: get(app.spec.syncPolicy, "automated") != nil && app.status.sync.status == "Synced" && app.status.health.status == "Healthy" && app.status.operationState.syncResult.revision != nil
+              oncePer: app.status.operationState.syncResult.revision
+              send:
+              - cf-promotion-app-revision-changed-template
+          trigger.cf-promotion-on-out-of-sync-trigger: |
+            - description: Application is out of sync (when autoHeal is off). Triggered once per commit.
+              when: get(app.spec.syncPolicy, "automated") == nil && app.status.sync.status == "OutOfSync" && app.status.operationState.syncResult.revision != nil
+              oncePer: app.status.operationState.syncResult.revision
+              send:
+              - cf-promotion-app-revision-changed-template
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Argo Events


### PR DESCRIPTION
## What
fix notification configuration overrides

## Why
allow end users to define their own `argo-cd.notifications` fields, without it messing with configurations we need for the promotion flows

## Notes
<!-- Add any notes here -->