### PR TITLE
Release-0.7.1

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -18,6 +18,9 @@ annotations:
       description: "updated codefresh-gitops-operator chart to 1.0.16"
     - kind: changed
       description: "updated cap-app-proxy to 1.2835.0"
+    - kind: added
+      description: garage as optional dependency for Argo workflows artifact and log storage
+
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
@@ -46,3 +49,8 @@ dependencies:
   version: 1.0.16
   alias: gitops-operator
   condition: gitops-operator.enabled
+- name: garage
+  repository: https://codefresh-io.github.io/garage
+  alias: garage-workflows-artifact-storage
+  version: 0.5.0-cf.1
+  condition: garage-workflows-artifact-storage.enabled && argo-workflows.enabled

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -56,4 +56,4 @@ dependencies:
   repository: https://codefresh-io.github.io/garage
   alias: garage-workflows-artifact-storage
   version: 0.5.0-cf.1
-  condition: garage-workflows-artifact-storage.enabled && argo-workflows.enabled
+  condition: garage-workflows-artifact-storage.enabled

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -14,8 +14,6 @@ maintainers:
 annotations:
   artifacthub.io/alternativeName: "codefresh-gitops-runtime"
   artifacthub.io/changes: |
-    - kind: security
-      description: "Add redis authentication to ArgoCD"
     - kind: changed
       description: "updated codefresh-gitops-operator chart to 1.0.15"
     - kind: changed

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -15,7 +15,7 @@ annotations:
   artifacthub.io/alternativeName: "codefresh-gitops-runtime"
   artifacthub.io/changes: |
     - kind: changed
-      description: "updated codefresh-gitops-operator chart to 1.0.15"
+      description: "updated codefresh-gitops-operator chart to 1.0.16"
     - kind: changed
       description: "updated cap-app-proxy to 1.2835.0"
 dependencies:
@@ -43,6 +43,6 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 1.0.15
+  version: 1.0.16
   alias: gitops-operator
   condition: gitops-operator.enabled

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
     - kind: security
       description: "Add redis authentication to ArgoCD"
     - kind: changed
-      description: "Updated ArgoCD templates - please note that this version of the ArgoCD templates contains a breaking change for ArgoCD server ingress value structure - runtime ingress is not affected. Only relevant if argo-cd.server.ingress.enabled is true. For the new ingress value structure please see: https://github.com/codefresh-io/argo-helm/blob/f98f2f4d4aca081e7b26cbb1a3fcec138bb3d4ac/charts/argo-cd/values.yaml#L2126-L2329"
+      description: "updated codefresh-gitops-operator chart to 1.0.14 (use argocd-notifications-controller in a sidecar)"
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
@@ -43,6 +43,6 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 1.0.13
+  version: 1.0.14
   alias: gitops-operator
   condition: gitops-operator.enabled

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -18,6 +18,8 @@ annotations:
       description: "Add redis authentication to ArgoCD"
     - kind: changed
       description: "updated codefresh-gitops-operator chart to 1.0.15"
+    - kind: changed
+      description: "updated cap-app-proxy to 1.2835.0"
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.1.48
+appVersion: 0.1.49
 description: A Helm chart for Codefresh gitops runtime
 name: gitops-runtime
-version: 0.7.0
+version: 0.7.1
 home: https://github.com/codefresh-io/gitops-runtime-helm
 icon: https://avatars1.githubusercontent.com/u/11412079?v=3
 keywords:

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -20,6 +20,8 @@ annotations:
       description: "updated cap-app-proxy to 1.2835.0"
     - kind: added
       description: garage as optional dependency for Argo workflows artifact and log storage
+    - kind: fixed
+      description: multiarch image for installer image used in hooks
 
 dependencies:
 - name: argo-cd

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
     - kind: security
       description: "Add redis authentication to ArgoCD"
     - kind: changed
-      description: "updated codefresh-gitops-operator chart to 1.0.14 (use argocd-notifications-controller in a sidecar)"
+      description: "updated codefresh-gitops-operator chart to 1.0.15"
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
@@ -43,6 +43,6 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 1.0.14
+  version: 1.0.15
   alias: gitops-operator
   condition: gitops-operator.enabled

--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -100,14 +100,14 @@ sealed-secrets:
 | app-proxy.image-enrichment.serviceAccount.name | string | `"codefresh-image-enrichment-sa"` | Name of the service account to create or the name of the existing one to use |
 | app-proxy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | app-proxy.image.repository | string | `"quay.io/codefresh/cap-app-proxy"` |  |
-| app-proxy.image.tag | string | `"1.2825.1"` |  |
+| app-proxy.image.tag | string | `"1.2835.0"` |  |
 | app-proxy.imagePullSecrets | list | `[]` |  |
 | app-proxy.initContainer.command[0] | string | `"./init.sh"` |  |
 | app-proxy.initContainer.env | object | `{}` |  |
 | app-proxy.initContainer.extraVolumeMounts | list | `[]` | Extra volume mounts for init container |
 | app-proxy.initContainer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | app-proxy.initContainer.image.repository | string | `"quay.io/codefresh/cap-app-proxy-init"` |  |
-| app-proxy.initContainer.image.tag | string | `"1.2825.1"` |  |
+| app-proxy.initContainer.image.tag | string | `"1.2835.0"` |  |
 | app-proxy.initContainer.resources.limits.cpu | string | `"1"` |  |
 | app-proxy.initContainer.resources.limits.memory | string | `"512Mi"` |  |
 | app-proxy.initContainer.resources.requests.cpu | string | `"0.2"` |  |

--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -233,6 +233,13 @@ sealed-secrets:
 | event-reporters.workflow.sensor.retryStrategy.steps | int | `3` | Number of retries |
 | event-reporters.workflow.sensor.tolerations | list | `[]` |  |
 | event-reporters.workflow.serviceAccount.create | bool | `true` |  |
+| garage-workflows-artifact-storage | object | `{"deployment":{"kind":"StatefulSet","replicaCount":3},"enabled":false,"fullnameOverride":"garage","garage":{"replicationMode":3},"persistence":{"data":{"size":"100Mi","storageClass":""},"enabled":true,"meta":{"size":"100Mi","storageClass":""}},"resources":{}}` | Builtin Workflows artifacts storage solution. Local S3 backed by local persistence with (PV and PVC) |
+| garage-workflows-artifact-storage.deployment.kind | string | `"StatefulSet"` | Only statefulset is supported for Codefresh gitops runtime. Do not change this |
+| garage-workflows-artifact-storage.persistence.data | object | `{"size":"100Mi","storageClass":""}` | Volume that stores artifacts and logs for workflows |
+| garage-workflows-artifact-storage.persistence.data.storageClass | string | `""` | When empty value empty the default storage class for the cluster will be used |
+| garage-workflows-artifact-storage.persistence.meta | object | `{"size":"100Mi","storageClass":""}` | Volume that stores cluster metadata |
+| garage-workflows-artifact-storage.persistence.meta.storageClass | string | `""` | When empty value empty the default storage class for the cluster will be used |
+| garage-workflows-artifact-storage.resources | object | `{}` | Resources for garage pods. For smaller deployments at least 100m CPU and 1024Mi memory is reccommended. For larger deployments double this size. |
 | gitops-operator.affinity | object | `{}` |  |
 | gitops-operator.crds | object | `{"additionalLabels":{},"annotations":{},"install":true,"keep":false}` | Codefresh gitops operator crds |
 | gitops-operator.crds.additionalLabels | object | `{}` | Additional labels for gitops operator CRDs |

--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -1,5 +1,5 @@
 ## Codefresh gitops runtime
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 0.1.48](https://img.shields.io/badge/AppVersion-0.1.48-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![AppVersion: 0.1.49](https://img.shields.io/badge/AppVersion-0.1.49-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ We have created a helper utility to resolve this issue:
 The utility is packaged in a container image. Below are instructions on executing the utility using Docker:
 
 ```
-docker run -v <output_dir>:/output quay.io/codefresh/gitops-runtime-private-registry-utils:0.7.0 <local_registry>
+docker run -v <output_dir>:/output quay.io/codefresh/gitops-runtime-private-registry-utils:0.7.1 <local_registry>
 ```
 `output_dir` - is a local directory where the utility will output files. <br>
 `local_registry` - is your local registry where you want to mirror the images to

--- a/charts/gitops-runtime/ci/values-all-images.yaml
+++ b/charts/gitops-runtime/ci/values-all-images.yaml
@@ -36,3 +36,6 @@ argo-cd:
   redis:
     exporter:
       enabled: true
+
+garage-workflows-artifact-storage:
+  enabled: true

--- a/charts/gitops-runtime/tests/values/mandatory-values-ingress.yaml
+++ b/charts/gitops-runtime/tests/values/mandatory-values-ingress.yaml
@@ -1,6 +1,6 @@
 global:
   codefresh:
-    accountId: 628a80b693a15c0f9c13ab75 # Codefresh Account id for ilia-codefresh for now, needs to be some test account
+    accountId: 628a80b693a15c0f9c13ab75
     userToken:
       token: 'dummy'
 

--- a/charts/gitops-runtime/tests/values/mandatory-values-no-token.yaml
+++ b/charts/gitops-runtime/tests/values/mandatory-values-no-token.yaml
@@ -1,6 +1,6 @@
 global:
   codefresh:
-    accountId: 628a80b693a15c0f9c13ab75 # Codefresh Account id for ilia-codefresh for now, needs to be some test account
+    accountId: 628a80b693a15c0f9c13ab75
 
   runtime:
     name: test-runtime1

--- a/charts/gitops-runtime/tests/values/mandatory-values.yaml
+++ b/charts/gitops-runtime/tests/values/mandatory-values.yaml
@@ -1,6 +1,6 @@
 global:
   codefresh:
-    accountId: 628a80b693a15c0f9c13ab75 # Codefresh Account id for ilia-codefresh for now, needs to be some test account
+    accountId: 628a80b693a15c0f9c13ab75
     userToken:
       token: 'dummy'
 

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -494,7 +494,7 @@ app-proxy:
           tag: 1.1.10-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.2825.1
+    tag: 1.2835.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -502,7 +502,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.2825.1
+      tag: 1.2835.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -675,3 +675,28 @@ gitops-operator:
       requests:
         cpu: 100m
         memory: 64Mi
+# -- Builtin Workflows artifacts storage solution. Local S3 backed by local persistence with (PV and PVC)
+garage-workflows-artifact-storage:
+  fullnameOverride: garage
+  enabled: false
+  deployment:
+    # -- Only statefulset is supported for Codefresh gitops runtime. Do not change this
+    kind: StatefulSet
+    replicaCount: 3
+  garage:
+    #-- Default to 3 replicas, see the replication_mode section at https://garagehq.deuxfleurs.fr/documentation/reference-manual/configuration/#replication-mode
+    replicationMode: 3
+  persistence:
+    enabled: true
+    # -- Volume that stores cluster metadata
+    meta:
+      # -- When empty value empty the default storage class for the cluster will be used
+      storageClass: ""
+      size: 100Mi
+    # -- Volume that stores artifacts and logs for workflows
+    data:
+      # -- When empty value empty the default storage class for the cluster will be used
+      storageClass: ""
+      size: 100Mi
+  # -- Resources for garage pods. For smaller deployments at least 100m CPU and 1024Mi memory is reccommended. For larger deployments double this size.
+  resources: {}

--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM debian:bullseye-slim
+FROM debian:bullseye-slim
 
 ARG CF_CLI_VERSION=v0.1.60
 ARG KUBECTL_VERSION=v1.27.2

--- a/scripts/private-registry-utils/Dockerfile
+++ b/scripts/private-registry-utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM python:3.11.3-slim-bullseye
+FROM python:3.11.3-slim-bullseye
 ARG TARGETARCH
 RUN cd /tmp && python3 -c "from urllib.request import urlretrieve; urlretrieve('https://get.helm.sh/helm-v3.12.0-linux-${TARGETARCH}.tar.gz', 'helm-v3.12.0-linux-${TARGETARCH}.tar.gz')"  && tar -xvf helm-v3.12.0-linux-${TARGETARCH}.tar.gz && chmod +x linux-${TARGETARCH}/helm && mv linux-${TARGETARCH}/helm /usr/local/bin/helm && rm -rf /tmp/*
 COPY charts/gitops-runtime /chart


### PR DESCRIPTION
## What
* updated codefresh-gitops-operator chart to 1.0.17
    * BREAKING CHANGE: no longer checking commit message for `[promotion:<flow>]` in operator side. making the check according to Product definition in the platform side
    * added argocd-notifications-controller as sidecar in gitops-operator pod
    * allow empty Release label on promotion-wrapper Workflow
* updated cap-app-proxy to 1.2835.0
* Add garage for workflow artifacts and logs (disabled by default)
* support multi-arch in tunnel-client

## Why

## Notes
<!-- Add any notes here -->