### PR TITLE
Updated gitops-operator chart to 1.0.16

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -15,7 +15,7 @@ annotations:
   artifacthub.io/alternativeName: "codefresh-gitops-runtime"
   artifacthub.io/changes: |
     - kind: changed
-      description: "updated codefresh-gitops-operator chart to 1.0.15"
+      description: "updated codefresh-gitops-operator chart to 1.0.16"
     - kind: changed
       description: "updated cap-app-proxy to 1.2835.0"
 dependencies:
@@ -43,6 +43,6 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 1.0.15
+  version: 1.0.16
   alias: gitops-operator
   condition: gitops-operator.enabled


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->