### PR TITLE
patch - disable ipv6 by default in internal router

### DIFF
--- a/charts/gitops-runtime/templates/_components/internal-router/_configmap.yaml
+++ b/charts/gitops-runtime/templates/_components/internal-router/_configmap.yaml
@@ -7,7 +7,9 @@ data:
   default.conf.template: |
     server {
       listen 8080;
+      {{- if .Values.ipv6.enabled }}
       listen [::]:8080 default_server;
+      {{- end }}
       access_log /dev/stdout main;
       error_log /dev/stdout;
       port_in_redirect off;

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -317,6 +317,9 @@ internal-router:
   imagePullSecrets: []
   nameOverride: ""
   fullnameOverride: "internal-router"
+  # -- For ipv6 enabled clusters switch ipv6 enabled to true
+  ipv6:
+    enabled: false
   serviceAccount:
     create: true
     annotations: {}


### PR DESCRIPTION
## What
Disable ipv6 by default in internal router
