### PR TITLE
feat: gitops-operator update with critical and high vuln fixes

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.52
+appVersion: 0.1.53
 description: A Helm chart for Codefresh gitops runtime
 name: gitops-runtime
 version: 0.0.0
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.1.4
+  version: 0.1.5
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What
this same changes as in https://github.com/codefresh-io/gitops-runtime-helm/pull/238/files
but according to new release flow
## Why

## Notes
<!-- Add any notes here -->