### PR TITLE
Feat: update argo-workflows chart to 0.41.11-v3.5.8-cap-CR-22608

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.0.9-1-cap-CR-19893
 - name: argo-workflows
   repository: https://codefresh-io.github.io/argo-helm
-  version: 0.40.9-1-v3.5.4-cap-CR-22243
+  version: 0.41.11-v3.5.8-cap-CR-22608
   condition: argo-workflows.enabled
 - name: argo-rollouts
   repository: https://codefresh-io.github.io/argo-helm


### PR DESCRIPTION
## What
update argo-workflows chart to 0.41.11-v3.5.8-cap-CR-22608

## Why
syncing with argo-workflows upstream, fixing sec-vulns

## Notes
<!-- Add any notes here -->