### PR TITLE
feat: add commit info in tasks

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.2.2
+  version: 0.2.5
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -448,7 +448,7 @@ app-proxy:
           tag: 1.1.10-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.2946.0
+    tag: 1.2962.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -456,7 +456,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.2946.0
+      tag: 1.2962.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
updated app-proxy image to 1.2962.0
updated gitops-operator helm chart to 0.2.5

## Why
gitops-operator will get commitInfo data when creating a promotion-workflow for a manual trigger made by the user.
this will require the platform to run api-graphql >=1.2962.0

## Notes
<!-- Add any notes here -->