### PR TITLE
feat: update app-proxy to `1.2987.1`

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -448,7 +448,7 @@ app-proxy:
           tag: 1.1.10-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.2969.0
+    tag: 1.2987.1
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -456,7 +456,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.2969.0
+      tag: 1.2987.1
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
update app-proxy to `1.2987.1`

## Why
adds support for new drag-n-drop query, that operates the same way as other promotion flows (manual trigger or git trigger)

## Notes
<!-- Add any notes here -->