### PR TITLE
chore: added default value and description for ingress `switchValidation`

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -54,6 +54,8 @@ global:
     codefreshHosted: false
     # -- Ingress settings
     ingress:
+      # -- if set to true, the pre-install hook will validate the existance of appropriate values, but *will not* attempt to make a web request to the ingress host
+      skipValidation: false
       # -- The protocol that Codefresh platform will use to access the runtime ingress. Can be http or https.
       protocol: https
       # -- Defines if ingress-based access mode is enabled for runtime. To use tunnel-based (ingressless) access mode, set to false.


### PR DESCRIPTION
## What
added default value of `false`

## Why
this value is already being used in pre-install hook. if set - will not attempt to make a web request to ingress host

## Notes
<!-- Add any notes here -->