### PR TITLE
feat: support PR in promotions

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.2.12
+  version: 0.2.13
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -415,7 +415,7 @@ app-proxy:
           tag: 1.1.10-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3036.0-CR-22781-get-pr-by-sha-182b8b5
+    tag: 1.3036.0-CR-22781-get-pr-by-sha-909a925
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -423,7 +423,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3036.0-CR-22781-get-pr-by-sha-182b8b5
+      tag: 1.3036.0-CR-22781-get-pr-by-sha-909a925
       pullPolicy: IfNotPresent
     command:
       - ./init.sh

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -415,7 +415,7 @@ app-proxy:
           tag: 1.1.10-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3021.0
+    tag: 1.3036.0-CR-22781-get-pr-by-sha-182b8b5
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -423,7 +423,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3021.0
+      tag: 1.3036.0-CR-22781-get-pr-by-sha-182b8b5
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
* bump gitops-operator to `v0.2.13`- support PR in promotion-wrapper and webhook
* bump cap-app-proxy to `vX.Y.Z` - expose `mergedPullRequestBySha` query

## Why
add required pieces to support promotions using Pull Requests

## Notes
<!-- Add any notes here -->