### PR TITLE
bump app-proxy to `1.3059.0` - fix hosted runtime init

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -415,7 +415,7 @@ app-proxy:
           tag: 1.1.10-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3056.1
+    tag: 1.3059.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -423,7 +423,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3056.1
+      tag: 1.3059.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
the default git integration is automatically being created in app-proxy code, on initialization. it gets the gitProvider and gitApiUrl from the account.csdp data in mongo, and doesn't need to be created in this initManagedRuntime function explicitly.

## Why
without it, clicking on "connect" after creating a new hosted runtime would always fail.

## Notes
<!-- Add any notes here -->