### PR TITLE
fix:upgrade gitops operator to 0.3.1 to publish error to product rele…

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.2.13
+  version: 0.3.1
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
…ase in case failed to create workflow

## What
publish error to product release in case failed to create workflow
## Why
avoid release stack on running when workflow cant be created
## Notes
<!-- Add any notes here -->