### PR TITLE
feat: Add Product Release Initiator functionality

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.1
+  version: 0.3.2
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -428,7 +428,7 @@ app-proxy:
           tag: 1.1.10-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3094.0
+    tag: 1.3098.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -436,7 +436,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3094.0
+      tag: 1.3098.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
Updating codefresh-gitops-operator and cap-app-proxy to new versions.

## Why
The new version includes changes to help show the initiator of promotion product releases triggered from a git commit.

## Notes
https://codefresh-io.atlassian.net/browse/CR-23402
Original PR 1: https://github.com/codefresh-io/gitops-runtime-helm/pull/303
Original PR 2: https://github.com/codefresh-io/gitops-runtime-helm/pull/304

argo-platform changes: https://github.com/codefresh-io/argo-platform/pull/5617
gitops-operator changes: https://github.com/codefresh-io/codefresh-gitops-operator/pull/87