### PR TITLE
fix: inject the correct argo-cd server url into gitops-operator

### DIFF
--- a/charts/gitops-runtime/templates/gitops-operator.yaml
+++ b/charts/gitops-runtime/templates/gitops-operator.yaml
@@ -15,7 +15,9 @@
   {{/* Set repo server service and port */}}
   {{- $_ := set $gitopsOperatorContext.Values.argoCdNotifications.argocd.repoServer "fullname" (include "codefresh-gitops-runtime.argocd.reposerver.servicename" . ) }}
   {{- $_ := set $gitopsOperatorContext.Values.argoCdNotifications.argocd.repoServer "port" (include "codefresh-gitops-runtime.argocd.reposerver.serviceport" . ) }}
-
+  
+  {{/* Set argo-cd-server service and port */}}
+  {{- $_ := set $gitopsOperatorContext.Values.env "ARGO_CD_URL" (include "codefresh-gitops-runtime.argocd.server.url" . ) }}
 
   {{/* Set workflows url */}}
   {{- if index .Values "argo-workflows" "enabled" }}


### PR DESCRIPTION
## What
when a customer sets argo-cd `fullnameOverride`, propagate the value into the gitops-operator subchart

## Why

## Notes
<!-- Add any notes here -->