### PR TITLE
chore: update cap-app-proxy to `1.3131.0` - improve locking around git operations

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -428,7 +428,7 @@ app-proxy:
           tag: 1.1.11-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3127.1
+    tag: 1.3131.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -436,7 +436,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3127.1
+      tag: 1.3131.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
new app-proxy handles git operation in a much better way

## Why
the main problem was a promotion release trying to commit to multiple applications in the same runtime, in parallel. the new app-proxy handles it without a problem.

## Notes
<!-- Add any notes here -->