### PR TITLE
fix: use the rootpath from argo-cd config.params values, when injecting ARGO_CD_URL to gitops-operator

### DIFF
--- a/charts/gitops-runtime/templates/_helpers.tpl
+++ b/charts/gitops-runtime/templates/_helpers.tpl
@@ -139,10 +139,11 @@ Determine argocd server url. Must be called with chart root context
 {{- $protocol := "https" }}
 {{- $serverName := include "codefresh-gitops-runtime.argocd.server.servicename" . }}
 {{- $port := include "codefresh-gitops-runtime.argocd.server.serviceport" . }}
+{{- $path := (get $argoCDValues.configs.params "server.rootpath") }}
 {{- if (eq $port "80") }}
   {{- $protocol = "http" }}
 {{- end }}
-{{- printf "%s://%s:%s" $protocol $serverName $port }}
+{{- printf "%s://%s:%s%s" $protocol $serverName $port $path }}
 {{- end}}
 
 {{/*

--- a/charts/gitops-runtime/templates/gitops-operator.yaml
+++ b/charts/gitops-runtime/templates/gitops-operator.yaml
@@ -17,7 +17,9 @@
   {{- $_ := set $gitopsOperatorContext.Values.argoCdNotifications.argocd.repoServer "port" (include "codefresh-gitops-runtime.argocd.reposerver.serviceport" . ) }}
   
   {{/* Set argo-cd-server service and port */}}
-  {{- $_ := set $gitopsOperatorContext.Values.env "ARGO_CD_URL" (include "codefresh-gitops-runtime.argocd.server.url" . ) }}
+  {{ if not (index .Values "gitops-operator").env.ARGO_CD_URL }}
+    {{- $_ := set $gitopsOperatorContext.Values.env "ARGO_CD_URL" (include "codefresh-gitops-runtime.argocd.server.url" . ) }}
+  {{- end }}
 
   {{/* Set workflows url */}}
   {{- if index .Values "argo-workflows" "enabled" }}

--- a/charts/gitops-runtime/tests/gitops-controller-misc_test.yaml
+++ b/charts/gitops-runtime/tests/gitops-controller-misc_test.yaml
@@ -329,7 +329,7 @@ tests:
       path: spec.template.spec.containers[1].env
       content:
         name: ARGO_CD_URL
-        value: http://myargocd-repo-server:80/some-path
+        value: http://myargocd-server:80/some-path
 
 - it: contains all resources for notifications controller
   template: gitops-operator.yaml
@@ -371,10 +371,11 @@ tests:
     argo-cd.configs.params:
       server.rootpath: /some-path
     argo-cd.fullnameOverride: myargocd
-    env.ARGO_CD_URL: http://some-other-url
+    gitops-operator.env.ARGO_CD_URL: http://some-other-url
   asserts:
   - contains:
       path: spec.template.spec.containers[1].env
       content:
         name: ARGO_CD_URL
         value: http://some-other-url
+

--- a/charts/gitops-runtime/tests/gitops-controller-misc_test.yaml
+++ b/charts/gitops-runtime/tests/gitops-controller-misc_test.yaml
@@ -304,11 +304,32 @@ tests:
   - contains:
       path: spec.template.spec.containers[2].args
       content: --argocd-repo-server=myargocd-repo-server:9080
+
+- it: argocd and workflows overrides for manager
+  template: gitops-operator.yaml
+  documentSelector:
+    path: kind
+    value: Deployment
+  values:
+  - ./values/mandatory-values.yaml
+  set:
+    argo-cd.configs.params:
+      server.rootpath: /some-path
+    argo-cd.fullnameOverride: myargocd
+    argo-workflows.enabled: true
+    argo-workflows.fullnameOverride: argo-test
+    argo-workflows.server.secure: false
+  asserts:
   - contains:
       path: spec.template.spec.containers[1].env
       content:
         name: ARGO_WF_URL
         value: http://argo-test-server:2746
+  - contains:
+      path: spec.template.spec.containers[1].env
+      content:
+        name: ARGO_CD_URL
+        value: http://myargocd-repo-server:80/some-path
 
 - it: contains all resources for notifications controller
   template: gitops-operator.yaml
@@ -318,23 +339,42 @@ tests:
     gitops-operator.argoCdNotifications.cm.name: "test-notifications-cm"
     gitops-operator.argoCdNotifications.secret.name: "test-notifications-secret"
   asserts:
-    - containsDocument:
-        kind: ConfigMap
-        apiVersion: v1
-        name: test-notifications-cm
-        any: true
-    - containsDocument:
-        kind: Secret
-        apiVersion: v1
-        name: test-notifications-secret
-        any: true
-    - containsDocument:
-        kind: ClusterRole
-        apiVersion: rbac.authorization.k8s.io/v1
-        name: codefresh-gitops-operator-notifications
-        any: true
-    - containsDocument:
-        kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1
-        name: codefresh-gitops-operator-notifications
-        any: true
+  - containsDocument:
+      kind: ConfigMap
+      apiVersion: v1
+      name: test-notifications-cm
+      any: true
+  - containsDocument:
+      kind: Secret
+      apiVersion: v1
+      name: test-notifications-secret
+      any: true
+  - containsDocument:
+      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      name: codefresh-gitops-operator-notifications
+      any: true
+  - containsDocument:
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      name: codefresh-gitops-operator-notifications
+      any: true
+
+- it: uses explicit ARGO_CD_URL instead of value defined by argo-cd settings
+  template: gitops-operator.yaml
+  documentSelector:
+    path: kind
+    value: Deployment
+  values:
+  - ./values/mandatory-values.yaml
+  set:
+    argo-cd.configs.params:
+      server.rootpath: /some-path
+    argo-cd.fullnameOverride: myargocd
+    env.ARGO_CD_URL: http://some-other-url
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[1].env
+      content:
+        name: ARGO_CD_URL
+        value: http://some-other-url


### PR DESCRIPTION
## What
use the defined argo-cd.configs.params['server.rootpath'] value when defining ARGO_CD_URL for gitops-operator

## Why

## Notes
<!-- Add any notes here -->