### PR TITLE
feat: change cap-app-proxy repo to GAR

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -427,7 +427,7 @@ app-proxy:
           repository: codefreshplugins/argo-hub-codefresh-csdp-image-enricher-jira-info
           tag: 1.1.11-main
   image:
-    repository: quay.io/codefresh/cap-app-proxy
+    repository: us-docker.pkg.dev/codefresh-inc/public-gcr-io/codefresh/cap-app-proxy
     tag: 1.3142.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
@@ -435,7 +435,7 @@ app-proxy:
 
   initContainer:
     image:
-      repository: quay.io/codefresh/cap-app-proxy-init
+      repository: us-docker.pkg.dev/codefresh-inc/public-gcr-io/codefresh/cap-app-proxy-init
       tag: 1.3142.0
       pullPolicy: IfNotPresent
     command:


### PR DESCRIPTION
## What

Move cap-app-proxy image to GAR

## Why

Due to Prisma being unable to scan images in quay.io (duplicate tags error)

## Notes
<!-- Add any notes here -->