### PR TITLE
chore: update gitops-operator to 0.3.8 - support manual-sync applications

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.6
+  version: 0.3.7
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
allow override of promotion-wrapper workflowTemplate

## What

## Why

## Notes
<!-- Add any notes here -->