### PR TITLE
fix: don't use protocol for ARGO_CD_URL in gitops-operator

### DIFF
--- a/charts/gitops-runtime/templates/_helpers.tpl
+++ b/charts/gitops-runtime/templates/_helpers.tpl
@@ -135,15 +135,24 @@ Determine argocd server service port. Must be called with chart root context
 Determine argocd server url. Must be called with chart root context
 */}}
 {{- define "codefresh-gitops-runtime.argocd.server.url" -}}
-{{- $argoCDValues := (get .Values "argo-cd") }}
 {{- $protocol := "https" }}
-{{- $serverName := include "codefresh-gitops-runtime.argocd.server.servicename" . }}
 {{- $port := include "codefresh-gitops-runtime.argocd.server.serviceport" . }}
-{{- $path := (get $argoCDValues.configs.params "server.rootpath") }}
 {{- if (eq $port "80") }}
   {{- $protocol = "http" }}
 {{- end }}
-{{- printf "%s://%s:%s%s" $protocol $serverName $port $path }}
+{{- $url := include "codefresh-gitops-runtime.argocd.server.no-protocol-url" . }}
+{{- printf "%s://%s" $protocol $url }}
+{{- end}}
+
+{{/*
+Determine argocd server url witout the protocol. Must be called with chart root context
+*/}}
+{{- define "codefresh-gitops-runtime.argocd.server.no-protocol-url" -}}
+{{- $argoCDValues := (get .Values "argo-cd") }}
+{{- $serverName := include "codefresh-gitops-runtime.argocd.server.servicename" . }}
+{{- $port := include "codefresh-gitops-runtime.argocd.server.serviceport" . }}
+{{- $path := (get $argoCDValues.configs.params "server.rootpath") }}
+{{- printf "%s:%s%s" $serverName $port $path }}
 {{- end}}
 
 {{/*

--- a/charts/gitops-runtime/templates/gitops-operator.yaml
+++ b/charts/gitops-runtime/templates/gitops-operator.yaml
@@ -18,7 +18,7 @@
   
   {{/* Set argo-cd-server service and port */}}
   {{ if not (index .Values "gitops-operator").env.ARGO_CD_URL }}
-    {{- $_ := set $gitopsOperatorContext.Values.env "ARGO_CD_URL" (include "codefresh-gitops-runtime.argocd.server.url" . ) }}
+    {{- $_ := set $gitopsOperatorContext.Values.env "ARGO_CD_URL" (include "codefresh-gitops-runtime.argocd.server.no-protocol-url" . ) }}
   {{- end }}
 
   {{/* Set workflows url */}}

--- a/charts/gitops-runtime/tests/gitops-controller-misc_test.yaml
+++ b/charts/gitops-runtime/tests/gitops-controller-misc_test.yaml
@@ -329,7 +329,7 @@ tests:
       path: spec.template.spec.containers[1].env
       content:
         name: ARGO_CD_URL
-        value: http://myargocd-server:80/some-path
+        value: myargocd-server:80/some-path
 
 - it: contains all resources for notifications controller
   template: gitops-operator.yaml
@@ -371,11 +371,11 @@ tests:
     argo-cd.configs.params:
       server.rootpath: /some-path
     argo-cd.fullnameOverride: myargocd
-    gitops-operator.env.ARGO_CD_URL: http://some-other-url
+    gitops-operator.env.ARGO_CD_URL: some-other-url:123
   asserts:
   - contains:
       path: spec.template.spec.containers[1].env
       content:
         name: ARGO_CD_URL
-        value: http://some-other-url
+        value: some-other-url:123
 


### PR DESCRIPTION
## What
gitops-operator should get ARGO_CD_URL without the protocol. the value ends up as an env variable to `argocd` binary, which fails if the protocol is supplied

## Why

## Notes
<!-- Add any notes here -->