### PR TITLE
fix: upgrade gitops-operator to 0.3.9 to add retry mechanism for sear…

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.8
+  version: 0.3.9
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
…ching suspend wrapper, in case was not suspend yet

## What

## Why

## Notes
<!-- Add any notes here -->