### PR TITLE
feat: updated codefresh-gitops-operator to 0.3.10

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.8
+  version: 0.3.10
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What
* fix: add retry in case workflow was not suspend yet (https://github.com/codefresh-io/codefresh-gitops-operator/pull/101)
* use argocd-get-global-tmpl on exit hook (https://github.com/codefresh-io/codefresh-gitops-operator/pull/103)


## Why

## Notes
<!-- Add any notes here -->