### PR TITLE
feat: base git-providers support

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.10
+  version: 0.3.11
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What
update codefresh-gitops-operator to 0.3.11

## Why
support non-github promotions (commit only)

## Notes
<!-- Add any notes here -->