### PR TITLE
feat: Add ability to set nodePort on internal-router service

### DIFF
--- a/charts/gitops-runtime/templates/_components/internal-router/_service.yaml
+++ b/charts/gitops-runtime/templates/_components/internal-router/_service.yaml
@@ -12,6 +12,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "internal-router.selectorLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
## What
I have discovered a relatively easy way to run a gitops runtime in a local Kind cluster against a local (dev) instance of codefresh running in docker. The only thing missing from the existing helm chart is the ability to set the `nodePort` value on the `internal-router` service. Note: You can already set the service type to `NodePort` but you just can't specify the nodePort that it uses, which we need to for my setup.

## Why
There has been some instability with the use of vclusters and so we're trying to find a way to run a local dev setup against a local cluster with a runtime. I believe I have found a solution that works quite well.

## Notes
Old PR: https://github.com/codefresh-io/gitops-runtime-helm/pull/347