### PR TITLE
chore: update codefresh-gitops-operator to 0.3.13

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.12
+  version: 0.3.13
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What

fix release retry in case it failed on workflow resume

## Why

## Notes
<!-- Add any notes here -->