### PR TITLE
fix: update argo-cd to 2.12.3-2024.12.23-4a8e092c0-with-dex-and-redis-bump

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -16,7 +16,7 @@ annotations:
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
-  version: 7.4.7-8-cap-2.12.3-2024.12.17-4d75d35f4
+  version: 7.4.7-10-cap-2.12.3-2024.12.23-4a8e092c0
 - name: argo-events
   repository: https://codefresh-io.github.io/argo-helm
   version: 2.4.7-1-cap-CR-24607


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->