### PR TITLE
fix: update cli-v2 from 0.1.68 to 0.1.69

### DIFF
--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -1,12 +1,11 @@
 FROM debian:bullseye-slim
 
-ARG CF_CLI_VERSION=v0.1.68
-ARG KUBECTL_VERSION=v1.28.12
+ARG CF_CLI_VERSION=v0.1.69
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install curl -y
 RUN curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/${CF_CLI_VERSION}/cf-linux-${TARGETARCH}.tar.gz | tar zx && mv ./cf-linux-${TARGETARCH} /usr/local/bin/cf
-RUN curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl && chmod +x kubectl && mv ./kubectl /usr/local/bin/kubectl
+COPY --from=bitnami/kubectl:1.32.0 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
 RUN adduser --shell /bin/bash codefresh
 USER codefresh


### PR DESCRIPTION
## What
* update cli-v2 from 0.1.68 to 0.1.69
* update kubectl from 1.28.12 to 1.32.0

## Why
fixes crutical
[CVE-2024-45337](https://pkg.go.dev/vuln/GO-2024-3321)
fixes high:
[CVE-2024-45338](https://pkg.go.dev/vuln/GO-2024-3333), [CVE-2024-45338](https://pkg.go.dev/vuln/GO-2024-3333), [PRISMA-2022-0227](https://github.com/emicklei/go-restful/issues/497)
fixes medium:
[CVE-2024-53862](https://pkg.go.dev/vuln/GO-2024-3303)

## Notes
<!-- Add any notes here -->