### PR TITLE
fix: security-vulns in codefresh-gitops-operator

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.17
+  version: 0.3.18
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.18
+  version: 0.3.19
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What
updated codefresh-gitops-operator to 0.3.19 [#111](https://github.com/codefresh-io/codefresh-gitops-operator/pull/111)

## Why
fixed security vulnerabilities
critical: [CVE-2024-45337](https://pkg.go.dev/vuln/GO-2024-3321)
high: [CVE-2024-5321](https://pkg.go.dev/vuln/GO-2024-2994), [CVE-2024-0793](https://pkg.go.dev/vuln/GO-2024-3277), [CVE-2024-40634](https://pkg.go.dev/vuln/GO-2024-3002)
medium: [CVE-2024-41666](https://pkg.go.dev/vuln/GO-2024-3006)
low: [CVE-2024-51744](https://pkg.go.dev/vuln/GO-2024-3250)

## Notes
<!-- Add any notes here -->