### PR TITLE
chore: upgrade gitops operator to 0.3.21 promotion wrapper retry

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.20
+  version: 0.3.21
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## Descriptions

 upgrade `codefresh-gitops-operator` to 0.3.21 - `promotion wrapper retry`