### PR TITLE
chore: updating cap-app-proxy with security fixes

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -438,7 +438,7 @@ app-proxy:
           tag: 1.1.12-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3228.0
+    tag: 1.3257.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []


### PR DESCRIPTION
## What
fixed https://github.com/advisories/GHSA-v778-237x-gjrc by ugrading bitnami-labs/sealed-secrets from 0.27.3 to 0.28.0
fixed https://github.com/advisories/GHSA-w32m-9786-jp63 by upgrading helm from v3.16.2 to v3.17.0
## Why

## Notes
<!-- Add any notes here -->