### PR TITLE
feat: upgrade Argo Rollouts to 1.7.2 plus security fixes

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
   condition: argo-workflows.enabled
 - name: argo-rollouts
   repository: https://codefresh-io.github.io/argo-helm
-  version: 2.37.3-1-v1.7.1-CR-24605
+  version: 2.37.3-2-v1.7.2-cap-CR-26082
   condition: argo-rollouts.enabled
 - name: sealed-secrets
   repository: https://bitnami-labs.github.io/sealed-secrets/


### PR DESCRIPTION
## What

* Argo Rollouts was updated from 1.7.1 to 1.7.2
* Extra security fixes were done (as reported by Prisma Cloud)

## Why

* To bring new features to customers
* To offer a secure distribution of Argo Rollouts 

## Notes

See JIRA CR-26082
<!-- Add any notes here -->