### PR TITLE
fix: bump argocd helm to argo-cd-7.7.14-3-cap-2.13.3-2025.2.12-7bfd6c858

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -16,7 +16,7 @@ annotations:
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
-  version: 7.7.14-1-cap-2.13.3-2025.1.16-39ce1d3d0
+  version: 7.7.14-3-cap-2.13.3-2025.2.12-7bfd6c858
 - name: argo-events
   repository: https://codefresh-io.github.io/argo-helm
   version: 2.4.7-1-cap-CR-26731


### PR DESCRIPTION
https://github.com/codefresh-io/argo-helm/pull/126
https://github.com/codefresh-io/argo-helm/releases/tag/argo-cd-7.7.14-3-cap-2.13.3-2025.2.12-7bfd6c858