### PR TITLE
chore(argo-workflows): bump argo-workflows to 0.45.2-v3.6.4-cap-CR-27392

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.23
+  version: 0.3.25
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->