### PR TITLE
chore(argo-workflows): bump argo-workflows to 0.45.2-v3.6.4-cap-CR-27392

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   version: 2.4.7-1-cap-CR-26731
 - name: argo-workflows
   repository: https://codefresh-io.github.io/argo-helm
-  version: 0.45.1-v3.6.2-cap-CR-26293
+  version: 0.45.2-v3.6.4-cap-CR-27392
   condition: argo-workflows.enabled
 - name: argo-rollouts
   repository: https://codefresh-io.github.io/argo-helm


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->