### PR TITLE
chore: bump gitops-operator version to 0.3.27

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.3.26
+  version: 0.3.27
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What
- Increase the num of retries to wait for workflow to be suspended = 31 sec in total
- Avoid looking for suspended workflow if there are no matching wrappers

## Why
Allow more time for wrapper to become suspended
