### PR TITLE
update argo-cd  helm chart version to 7.7.14-4-cap-2.13.3-2025.3.3-bd…

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -16,7 +16,7 @@ annotations:
 dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
-  version: 7.7.14-3-cap-2.13.3-2025.2.12-7bfd6c858
+  version: 7.7.14-4-cap-2.13.3-2025.3.3-bddbd99f7
 - name: argo-events
   repository: https://codefresh-io.github.io/argo-helm
   version: 2.4.7-1-cap-CR-26731


### PR DESCRIPTION
…dbd99f7

## What
- argo-helm contains a dex bump to 2.42.0
- argo-cd contains fix(ci): removed null security context from redis-ha values.yaml to placate helm 3.17.1
- argo-cd contains feat: bumped helm to 3.17.1
- argo-cd contains feat: bumped golang-jwt/jwt/v4 to 4.5.1
- argo-cd contains feat: bumped GitHub actions/cache to 4.2.0
## Why

## Notes
<!-- Add any notes here -->