### PR TITLE
chore: bump gitops-operator to version 0.4.7

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.4.5
+  version: 0.4.7
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What
bump gitops-operator to version 0.4.7

Related Issues:
 - [CR-27686](https://codefresh-io.atlassian.net/browse/CR-27686)
 - [CR-27071](https://codefresh-io.atlassian.net/browse/CR-27071)

## Why

## Notes
<!-- Add any notes here -->

[CR-27686]: https://codefresh-io.atlassian.net/browse/CR-27686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CR-27071]: https://codefresh-io.atlassian.net/browse/CR-27071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ