### PR TITLE
chore(deps): update codefresh-gitops-operator version to 0.5.2

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.5.1
+  version: 0.5.2
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What

## Why
gitops operator changes: https://github.com/codefresh-io/codefresh-gitops-operator/pull/136

## Notes
<!-- Add any notes here -->