### PR TITLE
patch - private registry external-argocd support and values structure fix

### DIFF
--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -103,6 +103,11 @@ The utility will output 4 files into the folder:
 3. `values-images-no-tags.yaml` - a values file with all image values with the private registry **excluding tags**. If provided through --values to helm install/upgrade command - it will override all images to use the private registry.
 4. `values-images-with-tags.yaml` - The same as 3 but with tags **included**.
 
+For usage with external ArgoCD run the utility with `EXTERNAL_ARGOCD` environment variable set to `true`.
+```
+docker run -e EXTERNAL_ARGOCD=true  -v <output_dir>:/output quay.io/codefresh/gitops-runtime-private-registry-utils:0.0.0 <local_registry>
+```
+
 ## Openshift
 
 ```yaml
@@ -166,14 +171,14 @@ sealed-secrets:
 | app-proxy.image-enrichment.serviceAccount.name | string | `"codefresh-image-enrichment-sa"` | Name of the service account to create or the name of the existing one to use |
 | app-proxy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | app-proxy.image.repository | string | `"quay.io/codefresh/cap-app-proxy"` |  |
-| app-proxy.image.tag | string | `"1.3353.1"` |  |
+| app-proxy.image.tag | string | `"1.3389.0"` |  |
 | app-proxy.imagePullSecrets | list | `[]` |  |
 | app-proxy.initContainer.command[0] | string | `"./init.sh"` |  |
 | app-proxy.initContainer.env | object | `{}` |  |
 | app-proxy.initContainer.extraVolumeMounts | list | `[]` | Extra volume mounts for init container |
 | app-proxy.initContainer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | app-proxy.initContainer.image.repository | string | `"quay.io/codefresh/cap-app-proxy-init"` |  |
-| app-proxy.initContainer.image.tag | string | `"1.3336.1"` |  |
+| app-proxy.initContainer.image.tag | string | `"1.3389.0"` |  |
 | app-proxy.initContainer.resources.limits | object | `{}` |  |
 | app-proxy.initContainer.resources.requests.cpu | string | `"0.2"` |  |
 | app-proxy.initContainer.resources.requests.memory | string | `"256Mi"` |  |
@@ -305,13 +310,6 @@ sealed-secrets:
 | gitops-operator.fullnameOverride | string | `""` |  |
 | gitops-operator.image | object | `{}` |  |
 | gitops-operator.imagePullSecrets | list | `[]` |  |
-| gitops-operator.kube-rbac-proxy.image.tag | string | `"v0.16.0"` |  |
-| gitops-operator.kube-rbac-proxy.resources.limits.cpu | string | `"500m"` |  |
-| gitops-operator.kube-rbac-proxy.resources.limits.memory | string | `"128Mi"` |  |
-| gitops-operator.kube-rbac-proxy.resources.requests.cpu | string | `"100m"` |  |
-| gitops-operator.kube-rbac-proxy.resources.requests.memory | string | `"64Mi"` |  |
-| gitops-operator.kube-rbac-proxy.securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| gitops-operator.kube-rbac-proxy.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | gitops-operator.libraryMode | bool | `true` | Do not change unless instructed otherwise by Codefresh support |
 | gitops-operator.nameOverride | string | `""` |  |
 | gitops-operator.nodeSelector | object | `{}` |  |
@@ -321,6 +319,12 @@ sealed-secrets:
 | gitops-operator.resources.limits | object | `{}` |  |
 | gitops-operator.resources.requests.cpu | string | `"100m"` |  |
 | gitops-operator.resources.requests.memory | string | `"128Mi"` |  |
+| gitops-operator.resources.resources.limits.cpu | string | `"500m"` |  |
+| gitops-operator.resources.resources.limits.memory | string | `"128Mi"` |  |
+| gitops-operator.resources.resources.requests.cpu | string | `"100m"` |  |
+| gitops-operator.resources.resources.requests.memory | string | `"64Mi"` |  |
+| gitops-operator.resources.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| gitops-operator.resources.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | gitops-operator.serviceAccount.annotations | object | `{}` |  |
 | gitops-operator.serviceAccount.create | bool | `true` |  |
 | gitops-operator.serviceAccount.name | string | `"gitops-operator-controller-manager"` |  |

--- a/charts/gitops-runtime/README.md.gotmpl
+++ b/charts/gitops-runtime/README.md.gotmpl
@@ -104,6 +104,13 @@ The utility will output 4 files into the folder:
 3. `values-images-no-tags.yaml` - a values file with all image values with the private registry **excluding tags**. If provided through --values to helm install/upgrade command - it will override all images to use the private registry.
 4. `values-images-with-tags.yaml` - The same as 3 but with tags **included**.
 
+
+For usage with external ArgoCD run the utility with `EXTERNAL_ARGOCD` environment variable set to `true`.
+```
+docker run -e EXTERNAL_ARGOCD=true  -v <output_dir>:/output quay.io/codefresh/gitops-runtime-private-registry-utils:{{ template "chart.version" . }} <local_registry>
+```
+
+
 ## Openshift
 
 ```yaml

--- a/charts/gitops-runtime/ci/values-external-argocd.yaml
+++ b/charts/gitops-runtime/ci/values-external-argocd.yaml
@@ -1,0 +1,34 @@
+# Values file used to render all image values
+global:
+  codefresh:
+    accountId: 628a80b693a15c0f9c13ab75 # Codefresh Account id for ilia-codefresh for now, needs to be some test account
+    gitIntegration:
+      provider:
+        name: 'GITHUB'
+        apiUrl: 'https://api.github.com'
+    userToken:
+      secretKeyRef:
+        name: mysecret
+        key: myvalue
+        optional: true
+
+  runtime:
+    name: default
+
+    ingress:
+      enabled: false
+
+    repoCredentialsTemplate:
+      url: 'https://github.com'
+      username: 'username'
+      password: 'dummy'
+
+argo-rollouts:
+  dashboard:
+    enabled: true
+
+argo-cd:
+  enabled: false
+
+garage-workflows-artifact-storage:
+  enabled: true

--- a/charts/gitops-runtime/templates/app-proxy/config.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/config.yaml
@@ -2,8 +2,8 @@
 {{ $argoCdUrl := include "codefresh-gitops-runtime.argocd.server.url" . }}
 {{ $argoCdUsername := include "codefresh-gitops-runtime.argocd.server.username-cm" . }}
 {{ $appProxyContext := deepCopy . }}
-{{ $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
-{{ $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{ $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
+{{ $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- if not $appProxyContext.Values.config.argoCdUrl }}
   {{ $_ := set $appProxyContext.Values.config "argoCdUrl" $argoCdUrl }}
 {{- end }}
@@ -14,7 +14,7 @@
     {{- $_ := set $appProxyContext.Values.config "argoWorkflowsUrl" $argoWorkflowsUrl }}
   {{- end }}
 {{- end}}
-{{- if not (index .Values "argo-cd" "enabled") }}
+{{- if not (index $.Values "argo-cd" "enabled") }}
   {{- $_ := set $appProxyContext.Values.config "isExternalArgoCD" "true" }}
 {{- else }}
   {{- $_ := set $appProxyContext.Values.config "isExternalArgoCD" "false" }}

--- a/charts/gitops-runtime/templates/app-proxy/deployment.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $appProxyContext := deepCopy . }}
-{{- $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
 {{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
 {{- $_ := set $appProxyContext.Values "argo-cd" (get .Values "argo-cd") }}
 

--- a/charts/gitops-runtime/templates/app-proxy/deployment.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $appProxyContext := deepCopy . }}
 {{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
-{{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- $_ := set $appProxyContext.Values "argo-cd" (get .Values "argo-cd") }}
 
 {{/* Merge environment variables with the ones in _app-proxy-env.yaml */}}

--- a/charts/gitops-runtime/templates/app-proxy/enrichment/rbac.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/enrichment/rbac.yaml
@@ -1,6 +1,6 @@
 {{- $appProxyContext := deepCopy . }}
 {{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
-{{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- if (index  (get $appProxyContext "Values") "image-enrichment" "enabled") }}
 {{- include "cap-app-proxy.image-enrichment.resources.role" $appProxyContext }}
 ---

--- a/charts/gitops-runtime/templates/app-proxy/enrichment/rbac.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/enrichment/rbac.yaml
@@ -1,5 +1,5 @@
 {{- $appProxyContext := deepCopy . }}
-{{- $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
 {{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
 {{- if (index  (get $appProxyContext "Values") "image-enrichment" "enabled") }}
 {{- include "cap-app-proxy.image-enrichment.resources.role" $appProxyContext }}

--- a/charts/gitops-runtime/templates/app-proxy/enrichment/sa.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/enrichment/sa.yaml
@@ -1,6 +1,6 @@
 {{- $appProxyContext := deepCopy . }}
 {{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
-{{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- if (index  (get $appProxyContext "Values") "image-enrichment" "enabled") }}
 {{- include "cap-app-proxy.image-enrichment.resources.sa" $appProxyContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/app-proxy/enrichment/sa.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/enrichment/sa.yaml
@@ -1,5 +1,5 @@
 {{- $appProxyContext := deepCopy . }}
-{{- $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
 {{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
 {{- if (index  (get $appProxyContext "Values") "image-enrichment" "enabled") }}
 {{- include "cap-app-proxy.image-enrichment.resources.sa" $appProxyContext }}

--- a/charts/gitops-runtime/templates/app-proxy/pdb.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $appProxyContext := deepCopy . }}
-{{- $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
-{{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 
 {{- if $appProxyContext.Values.pdb.enabled }}
 {{- include "cap-app-proxy.resources.pdb" $appProxyContext }}

--- a/charts/gitops-runtime/templates/app-proxy/rbac.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/rbac.yaml
@@ -1,4 +1,4 @@
 {{- $appProxyContext := deepCopy . }}
-{{- $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
-{{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- include "cap-app-proxy.resources.rbac" $appProxyContext }}

--- a/charts/gitops-runtime/templates/app-proxy/service.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/service.yaml
@@ -1,4 +1,4 @@
 {{- $appProxyContext := deepCopy . }}
-{{- $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
-{{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- include "cap-app-proxy.resources.service" $appProxyContext }}

--- a/charts/gitops-runtime/templates/app-proxy/serviceaccount.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/serviceaccount.yaml
@@ -1,4 +1,4 @@
 {{- $appProxyContext := deepCopy . }}
-{{- $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
-{{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- include "cap-app-proxy.resources.sa" $appProxyContext }}

--- a/charts/gitops-runtime/templates/app-proxy/workflows-crb.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/workflows-crb.yaml
@@ -1,8 +1,8 @@
 
 {{- if index (get .Values "argo-workflows") "enabled" }}
 {{- $appProxyContext := deepCopy . }}
-{{- $_ := set $appProxyContext "Values" (get .Values "app-proxy") }}
-{{- $_ := set $appProxyContext.Values "global" (get .Values "global") }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/clusterrolebinding.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/clusterrolebinding.yaml
@@ -4,8 +4,8 @@
 {{- if index (get .Values "argo-rollouts") "enabled" }}
   {{- if and (index (get .Values "argo-rollouts") "clusterInstall") (index (get .Values "argo-rollouts") "controller" "createClusterRole") }}
     {{- $eventReporterContext := deepCopy . }}
-    {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-    {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+    {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+    {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/eventsource.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/eventsource.yaml
@@ -1,6 +1,6 @@
 {{- if index (get .Values "argo-rollouts") "enabled" }}
   {{- $eventReporterContext := deepCopy . }}
-  {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-  {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+  {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+  {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
   {{- include "event-reporters.rollout-reporter.eventsource" $eventReporterContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/rbac.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if index (get .Values "argo-rollouts") "enabled" }}
   {{- $eventReporterContext := deepCopy . }}
-  {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-  {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+  {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+  {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
   {{- include "event-reporters.rollout-reporter.rbac" $eventReporterContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/sensor.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/sensor.yaml
@@ -1,6 +1,6 @@
 {{- if index (get .Values "argo-rollouts") "enabled" }}
   {{- $eventReporterContext := deepCopy . }}
-  {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-  {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+  {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+  {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
   {{- include "event-reporters.rollout-reporter.sensor" $eventReporterContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/serviceaccount.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- if index (get .Values "argo-rollouts") "enabled" }}
   {{- $eventReporterContext := deepCopy . }}
-  {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-  {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+  {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+  {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
   {{- include "event-reporters.rollout-reporter.sa" $eventReporterContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/event-reporters/workflow-reporter/eventsource.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/workflow-reporter/eventsource.yaml
@@ -1,7 +1,7 @@
 
 {{- if index (get .Values "argo-workflows") "enabled" }}
   {{- $eventReporterContext := deepCopy . }}
-  {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-  {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+  {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+  {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
   {{- include "event-reporters.workflow-reporter.eventsource" $eventReporterContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/event-reporters/workflow-reporter/rbac.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/workflow-reporter/rbac.yaml
@@ -1,7 +1,7 @@
 
 {{- if index (get .Values "argo-workflows") "enabled" }}
   {{- $eventReporterContext := deepCopy . }}
-  {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-  {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+  {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+  {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
   {{- include "event-reporters.workflow-reporter.rbac" $eventReporterContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/event-reporters/workflow-reporter/sensor.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/workflow-reporter/sensor.yaml
@@ -1,7 +1,7 @@
 
 {{- if index (get .Values "argo-workflows") "enabled" }}
   {{- $eventReporterContext := deepCopy . }}
-  {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-  {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+  {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+  {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
   {{- include "event-reporters.workflow-reporter.sensor" $eventReporterContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/event-reporters/workflow-reporter/serviceaccount.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/workflow-reporter/serviceaccount.yaml
@@ -1,7 +1,7 @@
 
 {{- if index (get .Values "argo-workflows") "enabled" }}
   {{- $eventReporterContext := deepCopy . }}
-  {{- $_ := set $eventReporterContext "Values" (get .Values "event-reporters") }}
-  {{- $_ := set $eventReporterContext.Values "global" (get .Values "global") }}
+  {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
+  {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}
   {{- include "event-reporters.workflow-reporter.sa" $eventReporterContext }}
 {{- end }}

--- a/charts/gitops-runtime/templates/gitops-operator.yaml
+++ b/charts/gitops-runtime/templates/gitops-operator.yaml
@@ -1,10 +1,10 @@
 {{- if and (index .Values "gitops-operator" "enabled") }}
 
 {{- if index (get .Values "gitops-operator") "libraryMode" }}
-  {{- $gitopsOperatorContext := (index .Subcharts "gitops-operator")}}
+  {{- $gitopsOperatorContext := (deepCopy (index .Subcharts "gitops-operator"))}}
 
   {{- if and (index .Subcharts "argo-cd") }}
-  
+
     {{- $argoCDImageDict := index .Subcharts "argo-cd" "Values" "global" "image" }}
     {{- if not $argoCDImageDict.tag }}
       {{- $_ := set $argoCDImageDict "tag" (get .Subcharts "argo-cd").Chart.AppVersion }}
@@ -17,7 +17,7 @@
     {{- end }}
 
   {{- else if and (index .Values "global" "external-argo-cd" "server" "image") }}
-    
+
     {{ $argoCDImageDict := (index .Values "global" "external-argo-cd" "server" "image") }}
 
     {{/* Set ArgoCD image */}}
@@ -31,9 +31,9 @@
   {{- end }}
 
   {{- if and (not (index .Values "argo-cd" "enabled")) }}
-    
+
     {{- if and (eq (index .Values "global" "external-argo-cd" "auth" "type") "token") }}
-      
+
       {{- if not (index .Values "global" "external-argo-cd" "auth" "token") }}
         {{- $_ := set $gitopsOperatorContext.Values.env "ARGO_CD_TOKEN_SECRET_NAME" (required ".Values.global.external-argo-cd.auth.type is set to 'token' therefore .Values.global.external-argo-cd.auth.tokenSecretKeyRef.name is required" (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "name")) }}
         {{- $_ := set $gitopsOperatorContext.Values.env "ARGO_CD_TOKEN_SECRET_KEY" (required ".Values.global.external-argo-cd.auth.type is set to 'token' therefore .Values.global.external-argo-cd.auth.tokenSecretKeyRef.key is required" (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "key")) }}
@@ -71,7 +71,7 @@
   {{- if and (gt (int $gitopsOperatorContext.Values.replicaCount) 1 ) }}
     {{- $_ := set $gitopsOperatorContext.Values.env "LEADER_ELECT" "true" }}
   {{- else }}
-    {{- $_ := set $gitopsOperatorContext.Values.env "LEADER_ELECT" "false" }}    
+    {{- $_ := set $gitopsOperatorContext.Values.env "LEADER_ELECT" "false" }}
   {{- end }}
 
   {{- include "gitops-operator.resources" $gitopsOperatorContext}}

--- a/charts/gitops-runtime/templates/internal-router/config.yaml
+++ b/charts/gitops-runtime/templates/internal-router/config.yaml
@@ -1,6 +1,6 @@
 {{- $internalRouterContext := deepCopy . }}
-{{- $_ := set $internalRouterContext "Values" (get .Values "internal-router") }}
-{{- $_ := set $internalRouterContext.Values "global" (get .Values "global") }}
+{{- $_ := set $internalRouterContext "Values" (deepCopy (get .Values "internal-router")) }}
+{{- $_ := set $internalRouterContext.Values "global" (deepCopy (get .Values "global")) }}
 {{/*
 Set workflows routing
 */}}

--- a/charts/gitops-runtime/templates/internal-router/deployment.yaml
+++ b/charts/gitops-runtime/templates/internal-router/deployment.yaml
@@ -1,4 +1,4 @@
 {{- $internalRouterContext := deepCopy . }}
-{{- $_ := set $internalRouterContext "Values" (get .Values "internal-router") }}
-{{- $_ := set $internalRouterContext.Values "global" (get .Values "global") }}
+{{- $_ := set $internalRouterContext "Values" (deepCopy (get .Values "internal-router")) }}
+{{- $_ := set $internalRouterContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- include "internal-router.resources.deployment" $internalRouterContext }}

--- a/charts/gitops-runtime/templates/internal-router/pdb.yaml
+++ b/charts/gitops-runtime/templates/internal-router/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $internalRouterContext := deepCopy . }}
-{{- $_ := set $internalRouterContext "Values" (get .Values "internal-router") }}
-{{- $_ := set $internalRouterContext.Values "global" (get .Values "global") }}
+{{- $_ := set $internalRouterContext "Values" (deepCopy (get .Values "internal-router")) }}
+{{- $_ := set $internalRouterContext.Values "global" (deepCopy (get .Values "global")) }}
 
 {{- if $internalRouterContext.Values.pdb.enabled }}
 {{- include "internal-router.resources.pdb" $internalRouterContext }}

--- a/charts/gitops-runtime/templates/internal-router/service.yaml
+++ b/charts/gitops-runtime/templates/internal-router/service.yaml
@@ -1,4 +1,4 @@
 {{- $internalRouterContext := deepCopy . }}
-{{- $_ := set $internalRouterContext "Values" (get .Values "internal-router") }}
-{{- $_ := set $internalRouterContext.Values "global" (get .Values "global") }}
+{{- $_ := set $internalRouterContext "Values" (deepCopy (get .Values "internal-router")) }}
+{{- $_ := set $internalRouterContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- include "internal-router.resources.service" $internalRouterContext }}

--- a/charts/gitops-runtime/templates/internal-router/serviceaccount.yaml
+++ b/charts/gitops-runtime/templates/internal-router/serviceaccount.yaml
@@ -1,4 +1,4 @@
 {{- $internalRouterContext := deepCopy . }}
-{{- $_ := set $internalRouterContext "Values" (get .Values "internal-router") }}
-{{- $_ := set $internalRouterContext.Values "global" (get .Values "global") }}
+{{- $_ := set $internalRouterContext "Values" (deepCopy (get .Values "internal-router")) }}
+{{- $_ := set $internalRouterContext.Values "global" (deepCopy (get .Values "global")) }}
 {{- include "internal-router.resources.sa" $internalRouterContext }}

--- a/charts/gitops-runtime/tests/gitops-controller-misc_test.yaml
+++ b/charts/gitops-runtime/tests/gitops-controller-misc_test.yaml
@@ -15,14 +15,7 @@ tests:
       image:
         repository: example.com/repo
         tag: 0.0.1
-      kube-rbac-proxy:
-        image:
-          repository: example.com/repo
-          tag: 0.0.1
   asserts:
-  - equal:
-      path: spec.template.spec.containers[0].image
-      value: example.com/repo:0.0.1
   - equal:
       path: spec.template.spec.containers[0].image
       value: example.com/repo:0.0.1
@@ -378,4 +371,3 @@ tests:
       content:
         name: ARGO_CD_URL
         value: some-other-url:123
-

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -667,13 +667,6 @@ gitops-operator:
       cpu: 100m
       memory: 128Mi
 
-  kube-rbac-proxy:
-    image:
-      tag: v0.16.0
-      # -- defaults
-      # repository: gcr.io/kubebuilder/kube-rbac-proxy
-      # tag: v0.14.1
-
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/scripts/private-registry-utils/Dockerfile
+++ b/scripts/private-registry-utils/Dockerfile
@@ -8,6 +8,4 @@ RUN pip3 install -r /scripts/python-requirements.txt
 COPY scripts/private-registry-utils /scripts
 RUN chmod -R +x /scripts
 WORKDIR /scripts
-# Output calculated values and filter image values
-RUN ./output-calculated-values.sh ./all-values.yaml && python3 ./helper-scripts/yaml-filter.py all-values.yaml image.repository,image.registry,image.tag,argo-events.configs.nats.versions,argo-events.configs.jetstream.versions,app-proxy.image-enrichment.config.images > all-image-values.yaml
-ENTRYPOINT ["python3", "private-registry-utils.py", "all-image-values.yaml"]
+ENTRYPOINT ["bash", "docker-entrypoint.sh"]

--- a/scripts/private-registry-utils/docker-entrypoint.sh
+++ b/scripts/private-registry-utils/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+export CHARTDIR="/chart"
+
+if [[ "$EXTERNAL_ARGOCD" == "true" ]]; then
+    export VALUESFILE="${CHARTDIR}/ci/values-external-argocd.yaml"
+else
+    export VALUESFILE="${CHARTDIR}/ci/values-all-images.yaml"
+fi
+
+./output-calculated-values.sh ./all-values.yaml
+python3 ./helper-scripts/yaml-filter.py all-values.yaml image.repository,image.registry,image.tag,argo-events.configs.nats.versions,argo-events.configs.jetstream.versions,app-proxy.image-enrichment.config.images,-global.external-argo-cd > all-image-values.yaml
+python3 private-registry-utils.py all-image-values.yaml $@

--- a/scripts/private-registry-utils/helper-scripts/yaml-filter.py
+++ b/scripts/private-registry-utils/helper-scripts/yaml-filter.py
@@ -14,6 +14,11 @@ def recurse_filter(currValue, filteredDict, filterKeyPathList, currentPath):
     for filterKeyPath in filterKeyPathList:
         if currentPath.endswith(filterKeyPath) and currValue:
             bMatched = True
+    # Exclude paths starting with "-"
+    for filterKeyPath in filterKeyPathList:
+        if filterKeyPath.startswith("-"):
+            if filterKeyPath[1:] in currentPath:
+                bMatched = False
     if bMatched == True:
         set_nested_dict_value(filteredDict,currentPath,currValue)
     elif type(currValue) is dict:
@@ -38,7 +43,7 @@ def main(yamlFilepath, filterKeys):
     lstFilterKeys = filterKeys.split(",")
     recurse_filter(d, filteredDict, lstFilterKeys, "")
     print(yaml.dump(filteredDict))
-        
+
 if __name__ == "__main__":
     if len(sys.argv) != 3:
         raise SyntaxError("Wrong number of arguments. Usage: filter-values.py <path to yaml> <key paths to filter by, separated by commas - for example image.repository,foo.bar>")

--- a/scripts/private-registry-utils/output-calculated-values.sh
+++ b/scripts/private-registry-utils/output-calculated-values.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-MYDIR=$(dirname $0)
-CHARTDIR="/chart"
-VALUESFILE="${CHARTDIR}/ci/values-all-images.yaml"
 OUTPUTFILE=$1
 # This template prints all values and also sets tags for all images with non-empty repository value, where the tag is empty and should be derived from the appVersion of the subchart.
 ALL_VALUES_TEMPLATE=$(cat <<END


### PR DESCRIPTION
## What
- Support external argocd in private registry utility
- Fix values structure - lack of use of deepCopy caused duplication of global values
- Cleanup gitops-operator leftover values that caused issues in image list generation
- Tag context setting from subchart fixed
## Why

## Notes
<!-- Add any notes here -->