### PR TITLE
feat: rollout-reporter with external argo rollouts

### DIFF
--- a/charts/gitops-runtime/templates/_helpers.tpl
+++ b/charts/gitops-runtime/templates/_helpers.tpl
@@ -118,10 +118,10 @@ Determine argocd argocd repo server port
 
 
 {{/*
-Determine argocd repoServer url 
+Determine argocd repoServer url
 */}}
 {{- define "codefresh-gitops-runtime.argocd.reposerver.url" -}}
-{{- $argoCDValues := (get .Values "argo-cd") }} 
+{{- $argoCDValues := (get .Values "argo-cd") }}
 {{- if and (index .Values "argo-cd" "enabled") }}
   {{- $serviceName := include "codefresh-gitops-runtime.argocd.reposerver.servicename" . }}
   {{- $port := include "codefresh-gitops-runtime.argocd.reposerver.serviceport" . }}
@@ -149,8 +149,12 @@ Determine argocd servicename. Must be called with chart root context
 Determine rollouts name
 */}}
 {{- define "codefresh-gitops-runtime.argo-rollouts.name" -}}
-{{/* For now use template from rollouts chart until better approach */}}
-{{- template "argo-rollouts.fullname" (dict "Values" (get .Values "argo-rollouts")) }}
+  {{- if and (index .Values "argo-rollouts" "enabled") }}
+    {{/* For now use template from rollouts chart until better approach */}}
+    {{- template "argo-rollouts.fullname" (dict "Values" (get .Values "argo-rollouts")) }}
+  {{- else }}
+    {{- printf "argo-rollouts" }}
+  {{- end }}
 {{- end }}
 
 
@@ -200,7 +204,7 @@ Determine argocd server url. Must be called with chart root context
     {{- $port := (required "ArgoCD is not enabled and .Values.global.external-argo-cd.server.port is not port" $argoCDSrv.port) | toString }}
     {{- $rootpath := (index .Values "global" "external-argo-cd" "server" "rootpath") }}
     {{- if and (eq $port "80") }}
-      {{- printf "%s://%s%s" $protocol $svc $rootpath }}    
+      {{- printf "%s://%s%s" $protocol $svc $rootpath }}
     {{- else }}
       {{- printf "%s://%s:%s%s" $protocol $svc $port $rootpath }}
     {{- end }}
@@ -213,7 +217,7 @@ Determine argocd server url. Must be called with chart root context
 Determine argocd server url witout the protocol. Must be called with chart root context
 */}}
 {{- define "codefresh-gitops-runtime.argocd.server.no-protocol-url" -}}
-{{- $argoCDValues := (get .Values "argo-cd") }} 
+{{- $argoCDValues := (get .Values "argo-cd") }}
 {{- if and (index .Values "argo-cd" "enabled") }}
   {{- $serverName := include "codefresh-gitops-runtime.argocd.server.servicename" . }}
   {{- $port := include "codefresh-gitops-runtime.argocd.server.serviceport" . }}
@@ -231,7 +235,7 @@ Determine argocd server url witout the protocol. Must be called with chart root 
 {{- end}}
 
 {{/*
-Determine argocd server password. 
+Determine argocd server password.
 */}}
 {{- define "codefresh-gitops-runtime.argocd.server.password" }}
   {{- if and (index .Values "argo-cd" "enabled") }}
@@ -265,7 +269,7 @@ valueFrom:
 
 
 {{/*
-Determine argocd token password. 
+Determine argocd token password.
 */}}
 {{- define "codefresh-gitops-runtime.argocd.server.token" }}
   {{- if and (eq (index .Values "global" "external-argo-cd" "auth" "type") "token") (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "name") (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "key")}}
@@ -289,7 +293,7 @@ valueFrom:
 {{- end }}
 
 {{/*
-Determine argocd server password. 
+Determine argocd server password.
 */}}
 {{- define "codefresh-gitops-runtime.argocd.server.username-env-var" }}
   {{- if and (index .Values "argo-cd" "enabled") }}
@@ -310,7 +314,7 @@ valueFrom:
 {{- end }}
 
 {{/*
-Determine argocd server password. 
+Determine argocd server password.
 */}}
 {{- define "codefresh-gitops-runtime.argocd.server.username-cm" }}
   {{- if and (index .Values "argo-cd" "enabled") }}
@@ -323,10 +327,10 @@ Determine argocd server password.
 {{- end }}
 
 {{/*
-Determine argocd redis url 
+Determine argocd redis url
 */}}
 {{- define "codefresh-gitops-runtime.argocd.redis.url" -}}
-{{- $argoCDValues := (get .Values "argo-cd") }} 
+{{- $argoCDValues := (get .Values "argo-cd") }}
 {{- if and (index .Values "argo-cd" "enabled") }}
   {{- $serviceName := include "codefresh-gitops-runtime.argocd.redis.servicename" . }}
   {{- $port := include "codefresh-gitops-runtime.argocd.redis.serviceport" . }}
@@ -458,7 +462,7 @@ Output comma separated list of installed runtime components
   {{- end }}
   {{- if not (index .Values "argo-cd" "enabled") }}
     {{- $eventReporter := dict "name" "event-reporter" "version" (get .Subcharts "cf-argocd-extras").Chart.AppVersion }}
-    {{- $comptList = append $comptList $eventReporter }} 
+    {{- $comptList = append $comptList $eventReporter }}
   {{- end }}
 {{- $comptList | toYaml }}
 {{- end }}

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/clusterrolebinding.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/clusterrolebinding.yaml
@@ -1,8 +1,8 @@
 {{/* Mapping of argo rollouts clusterrole if such is created (see https://github.com/codefresh-io/argo-helm/blob/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrolebinding.yaml)
  to the reporters ServiceAccount
 */}}
-{{- if index (get .Values "argo-rollouts") "enabled" }}
-  {{- if and (index (get .Values "argo-rollouts") "clusterInstall") (index (get .Values "argo-rollouts") "controller" "createClusterRole") }}
+{{- if or (index (get .Values "argo-rollouts") "enabled") (and (not (index (get .Values "argo-rollouts") "enabled")) (index .Values.global "external-argo-rollouts" "rollout-reporter" "enabled" )) }}
+  {{- if or (and (index (get .Values "argo-rollouts") "clusterInstall") (index (get .Values "argo-rollouts") "controller" "createClusterRole")) (and (not (index (get .Values "argo-rollouts") "enabled")) (index .Values.global "external-argo-rollouts" "rollout-reporter" "enabled" ))}}
     {{- $eventReporterContext := deepCopy . }}
     {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
     {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/eventsource.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/eventsource.yaml
@@ -1,4 +1,4 @@
-{{- if index (get .Values "argo-rollouts") "enabled" }}
+{{- if or (index (get .Values "argo-rollouts") "enabled") (and (not (index (get .Values "argo-rollouts") "enabled")) (index .Values.global "external-argo-rollouts" "rollout-reporter" "enabled" )) }}
   {{- $eventReporterContext := deepCopy . }}
   {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
   {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/rbac.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if index (get .Values "argo-rollouts") "enabled" }}
+{{- if or (index (get .Values "argo-rollouts") "enabled") (and (not (index (get .Values "argo-rollouts") "enabled")) (index .Values.global "external-argo-rollouts" "rollout-reporter" "enabled" )) }}
   {{- $eventReporterContext := deepCopy . }}
   {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
   {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/sensor.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/sensor.yaml
@@ -1,4 +1,4 @@
-{{- if index (get .Values "argo-rollouts") "enabled" }}
+{{- if or (index (get .Values "argo-rollouts") "enabled") (and (not (index (get .Values "argo-rollouts") "enabled")) (index .Values.global "external-argo-rollouts" "rollout-reporter" "enabled" )) }}
   {{- $eventReporterContext := deepCopy . }}
   {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
   {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}

--- a/charts/gitops-runtime/templates/event-reporters/rollout-reporter/serviceaccount.yaml
+++ b/charts/gitops-runtime/templates/event-reporters/rollout-reporter/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if index (get .Values "argo-rollouts") "enabled" }}
+{{- if or (index (get .Values "argo-rollouts") "enabled") (and (not (index (get .Values "argo-rollouts") "enabled")) (index .Values.global "external-argo-rollouts" "rollout-reporter" "enabled" )) }}
   {{- $eventReporterContext := deepCopy . }}
   {{- $_ := set $eventReporterContext "Values" (deepCopy (get .Values "event-reporters")) }}
   {{- $_ := set $eventReporterContext.Values "global" (deepCopy (get .Values "global")) }}

--- a/charts/gitops-runtime/tests/external_argo_rollouts_test.yaml
+++ b/charts/gitops-runtime/tests/external_argo_rollouts_test.yaml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test External Argo Rolouts with GitOps Runtime
+templates:
+  - event-reporters/rollout-reporter/*
+tests:
+  - it: Should not deploy rollout-reporter if argo-rollouts disabled
+    set:
+      argo-rollouts:
+        enabled: false
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: ServiceAccount
+          name: rollout-reporter
+        template: event-reporters/rollout-reporter/serviceaccount.yaml
+        not: true
+      - containsDocument:
+          apiVersion: argoproj.io/v1alpha1
+          kind: Sensor
+          name: rollout-reporter
+        template: event-reporters/rollout-reporter/sensor.yaml
+        not: true
+      - containsDocument:
+          apiVersion: argoproj.io/v1alpha1
+          kind: EventSource
+          name: rollout-reporter
+        template: event-reporters/rollout-reporter/eventsource.yaml
+        not: true
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          name: rollout-reporter-sa
+        template: event-reporters/rollout-reporter/rbac.yaml
+        not: true
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          name: rollout-reporter-sa
+        template: event-reporters/rollout-reporter/rbac.yaml
+        not: true
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          name: codefresh-rollouts-reporter
+        template: event-reporters/rollout-reporter/clusterrolebinding.yaml
+        not: true
+
+  - it: Should deploy rollout-reporter if argo-rollouts disabled AND .global.external-argo-rollouts.rollout-reporter.enabled is true
+    set:
+      argo-rollouts:
+        enabled: false
+      global:
+        external-argo-rollouts:
+          rollout-reporter:
+            enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: ServiceAccount
+          name: rollout-reporter
+        template: event-reporters/rollout-reporter/serviceaccount.yaml
+      - containsDocument:
+          apiVersion: argoproj.io/v1alpha1
+          kind: Sensor
+          name: rollout-reporter
+        template: event-reporters/rollout-reporter/sensor.yaml
+      - containsDocument:
+          apiVersion: argoproj.io/v1alpha1
+          kind: EventSource
+          name: rollout-reporter
+        template: event-reporters/rollout-reporter/eventsource.yaml
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          name: rollout-reporter-sa
+        template: event-reporters/rollout-reporter/rbac.yaml
+        documentIndex: 0
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          name: rollout-reporter-sa
+        template: event-reporters/rollout-reporter/rbac.yaml
+        documentIndex: 1
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          name: codefresh-rollouts-reporter
+        template: event-reporters/rollout-reporter/clusterrolebinding.yaml

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -162,6 +162,14 @@ global:
       #   name: argocd-token
       #   key: token
 
+  # -- Configuration for external Argo Rollouts
+  external-argo-rollouts:
+    # -- Rollout reporter settings
+    rollout-reporter:
+      # -- Enable or disable rollout reporter
+      # Configuration is defined at .Values.event-reporters.rollout
+      enabled: false
+
 # -------------------------------------------------------------------------------------------------------------------------
 # Installer
 # -------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What

Allow to install rollout-reporter with external Argo Rollouts.

```yaml
global:
  external-argo-rollouts:
    rollout-reporter:
      enabled: true

argo-rollouts:
  enabled: false
```

## Why

## Notes
<!-- Add any notes here -->