### PR TITLE
chore: bump gitops operator version

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.5.2
+  version: 0.5.4
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What
Bumping gitops operator version to include this change: https://github.com/codefresh-io/codefresh-gitops-operator/pull/144

## Why

## Notes
<!-- Add any notes here -->