### PR TITLE
feat: limits enforcement in runtime installation

### DIFF
--- a/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
@@ -1,0 +1,24 @@
+{{- if  not .Values.installer.skipUsageValidation }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: validate-usage
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: validate-values-sa
+      restartPolicy: Never
+      containers:
+      - name: validate-usage
+        image: "{{ .Values.installer.image.repository }}:{{ .Values.installer.image.tag | default .Chart.Version }}"
+        imagePullPolicy: {{ .Values.installer.image.pullPolicy }}
+        command: ["sh", "-c"]
+        args: 
+        - |
+          cf account validate-usage --fail-condition=reached --subject=clusters --log-level debug
+{{- end }}

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -177,6 +177,8 @@ global:
 installer:
   # -- if set to true, pre-install hook will *not* run
   skipValidation: false
+  # -- if set to true, pre-install hook will *not* run
+  skipUsageValidation: false
   image:
     repository: quay.io/codefresh/gitops-runtime-installer
     tag: ""

--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:12.9-slim
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-ARG CF_CLI_VERSION=v0.1.70
+ARG CF_CLI_VERSION=v0.2.6
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install curl -y


### PR DESCRIPTION
## What
A pre-install hook with the ability to be disabled
## Why
Prevents runtime installation if `clusters` limit is reached. 
The final validation will take place during the runtime registration on the platform.
This hook allows us to stop the installation at an early stage.
It's not a reliable mechanism, just an additional one to save time and resources.
## Notes
<!-- Add any notes here -->