### PR TITLE
feat: limits enforcement in runtime installation

### DIFF
--- a/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
@@ -50,7 +50,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
-    helm.sh/hook-weight: "-10"
+    helm.sh/hook-weight: "5"
 rules:
   - apiGroups:
       - "*"
@@ -66,7 +66,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
-    helm.sh/hook-weight: "-10"
+    helm.sh/hook-weight: "5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -83,5 +83,5 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
-    helm.sh/hook-weight: "-10"
+    helm.sh/hook-weight: "5"
 {{- end }}

--- a/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
@@ -54,11 +54,11 @@ metadata:
     helm.sh/hook-weight: "5"
 rules:
   - apiGroups:
-      - "*"
+      - ""
     resources:
-      - "*"
+      - secrets
     verbs:
-      - "*"
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if  not (and .Values.installer.skipValidation .Values.installer.skipUsageValidation) }}
+{{- if  not .Values.installer.skipValidation }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -38,6 +38,50 @@ metadata:
   name: validate-values-sa
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
+    helm.sh/hook-weight: "-10"
+{{- end }}
+
+{{- if  not .Values.installer.skipUsageValidation }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: validate-usage-cr
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
+    helm.sh/hook-weight: "-10"
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: validate-usage-crb
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
+    helm.sh/hook-weight: "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: validate-usage-cr
+subjects:
+  - kind: ServiceAccount
+    name: validate-usage-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: validate-usage-sa
+  annotations:
+    helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
     helm.sh/hook-weight: "-10"
 {{- end }}

--- a/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if  not .Values.installer.skipValidation }}
+{{- if  not (and .Values.installer.skipValidation .Values.installer.skipUsageValidation) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/rbac.yaml
@@ -43,6 +43,7 @@ metadata:
 {{- end }}
 
 {{- if  not .Values.installer.skipUsageValidation }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: validate-values-config
+  name: validate-usage-config
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
@@ -24,7 +24,7 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
-      serviceAccountName: validate-values-sa
+      serviceAccountName: validate-usage-sa
       restartPolicy: Never
       containers:
       - name: validate-usage
@@ -40,10 +40,10 @@ spec:
         - |
           cf account validate-usage --fail-condition=reached --subject=clusters --values /job_tmp/values.yaml --namespace ${NAMESPACE} --hook --log-level debug
         volumeMounts:
-          - name: customized-values
+          - name: validate-usage-volume
             mountPath: "/job_tmp"
       volumes:
-        - name: customized-values
+        - name: validate-usage-volume
           configMap:
-            name: validate-values-config
+            name: validate-usage-config
 {{- end }}

--- a/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: validate-usage
-        image: "{{ .Values.installer.image.repository }}:{{ .Values.installer.image.tag | default .Chart.Version }}"
+        image: docker.io/codefresh/cli-v2:cr-28341-val-lim
         imagePullPolicy: {{ .Values.installer.image.pullPolicy }}
         command: ["sh", "-c"]
         args: 

--- a/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
@@ -29,8 +29,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: validate-usage
-        image: "quay.io/codefresh/cli-v2:cr-28341-val-lim"
-        imagePullPolicy: Always
+        image: "{{ .Values.installer.image.repository }}:{{ .Values.installer.image.tag | default .Chart.Version }}"
+        imagePullPolicy: {{ .Values.installer.image.pullPolicy }}
         env:
         - name: NAMESPACE
           valueFrom:

--- a/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
@@ -1,0 +1,24 @@
+{{- if  not .Values.installer.skipUsageValidation }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: validate-usage
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: validate-values-sa
+      restartPolicy: Never
+      containers:
+      - name: validate-usage
+        image: "{{ .Values.installer.image.repository }}:{{ .Values.installer.image.tag | default .Chart.Version }}"
+        imagePullPolicy: {{ .Values.installer.image.pullPolicy }}
+        command: ["sh", "-c"]
+        args: 
+        - |
+          cf account validate-usage --fail-condition=reached --subject=clusters --log-level debug
+{{- end }}

--- a/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
@@ -28,8 +28,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: validate-usage
-        image: quay.io/codefresh/cli-v2:cr-28341-val-lim
-        imagePullPolicy: Always
+        image: "{{ .Values.installer.image.repository }}:{{ .Values.installer.image.tag | default .Chart.Version }}"
+        imagePullPolicy: {{ .Values.installer.image.pullPolicy }}
         env:
         - name: NAMESPACE
           valueFrom:

--- a/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
-    helm.sh/hook-weight: "-10"
+    helm.sh/hook-weight: "5"
 data:
   values.yaml: |
 {{ .Values | toYaml | indent 4 }}
@@ -19,6 +19,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    helm.sh/hook-weight: "10"
 spec:
   backoffLimit: 0
   ttlSecondsAfterFinished: 300
@@ -28,8 +29,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: validate-usage
-        image: "{{ .Values.installer.image.repository }}:{{ .Values.installer.image.tag | default .Chart.Version }}"
-        imagePullPolicy: {{ .Values.installer.image.pullPolicy }}
+        image: "quay.io/codefresh/cli-v2:cr-28341-val-lim"
+        imagePullPolicy: Always
         env:
         - name: NAMESPACE
           valueFrom:

--- a/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/validate-usage.yaml
@@ -1,4 +1,17 @@
 {{- if  not .Values.installer.skipUsageValidation }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: validate-values-config
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
+    helm.sh/hook-weight: "-10"
+data:
+  values.yaml: |
+{{ .Values | toYaml | indent 4 }}
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -15,10 +28,22 @@ spec:
       restartPolicy: Never
       containers:
       - name: validate-usage
-        image: docker.io/codefresh/cli-v2:cr-28341-val-lim
-        imagePullPolicy: {{ .Values.installer.image.pullPolicy }}
+        image: quay.io/codefresh/cli-v2:cr-28341-val-lim
+        imagePullPolicy: Always
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         command: ["sh", "-c"]
         args: 
         - |
-          cf account validate-usage --fail-condition=reached --subject=clusters --log-level debug
+          cf account validate-usage --fail-condition=reached --subject=clusters --values /job_tmp/values.yaml --namespace ${NAMESPACE} --hook --log-level debug
+        volumeMounts:
+          - name: customized-values
+            mountPath: "/job_tmp"
+      volumes:
+        - name: customized-values
+          configMap:
+            name: validate-values-config
 {{- end }}

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -177,6 +177,8 @@ global:
 installer:
   # -- if set to true, pre-install hook will *not* run
   skipValidation: false
+  # -- if set to true, pre-install hook will *not* run
+  skipUsageValidation: false
   image:
     repository: quay.io/codefresh/gitops-runtime-installer
     tag: ""

--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:12.10-slim
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-ARG CF_CLI_VERSION=v0.2.6
+ARG CF_CLI_VERSION=v0.2.7
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install curl -y

--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:12.10-slim
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-ARG CF_CLI_VERSION=v0.2.7
+ARG CF_CLI_VERSION=v0.2.6
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install curl -y

--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:12.9-slim
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-ARG CF_CLI_VERSION=v0.1.70
+ARG CF_CLI_VERSION=v0.2.6
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install curl -y

--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:12.9-slim
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-ARG CF_CLI_VERSION=v0.2.6
+ARG CF_CLI_VERSION=v0.2.7
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install curl -y


### PR DESCRIPTION
## What
A pre-install hook with the ability to be disabled
## Why
Prevents runtime installation if clusters limit is reached.
The final validation will take place during the runtime registration on the platform.
This hook allows us to stop the installation at an early stage.
It's not a reliable mechanism, just an additional one to save time and resources.
## Notes
This PR was recreated with new branch name from this one:
https://github.com/codefresh-io/gitops-runtime-helm/pull/452