### PR TITLE
feat: security fixes for Argo Rollouts 1.7.2

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   condition: argo-workflows.enabled
 - name: argo-rollouts
   repository: https://codefresh-io.github.io/argo-helm
-  version: 2.37.3-2-v1.7.2-cap-CR-26082
+  version: 2.37.3-3-v1.7.2-cap-CR-28008
   condition: argo-rollouts.enabled
 - name: sealed-secrets
   repository: https://bitnami-labs.github.io/sealed-secrets/


### PR DESCRIPTION
## What
Extra security fixes were done (as reported by Prisma Cloud)


## Why
To offer a secure distribution of Argo Rollouts

## Notes

See JIRA CR-28008