### PR TITLE
fix: update app-proxy image tag to 1.3470.0 - fix file revision validation

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -531,7 +531,7 @@ app-proxy:
           tag: 1.1.13-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3451.0
+    tag: 1.3470.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -539,7 +539,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3451.0
+      tag: 1.3470.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
update app-proxy image tag to `1.3470.0`

## Why
fixes promotion process file version checks, and retry push after pull+merge in correct cases

## Notes
<!-- Add any notes here -->