### PR TITLE
chore: update codefresh-gitops-operator version to 0.7.3 - fix missing argo-workflows permission

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.7.1
+  version: 0.7.3
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->