### PR TITLE
feat: enhance error handling for app-proxy with CORS support in internal router configmap

### DIFF
--- a/charts/gitops-runtime/templates/_components/internal-router/_configmap.yaml
+++ b/charts/gitops-runtime/templates/_components/internal-router/_configmap.yaml
@@ -27,7 +27,29 @@ data:
         proxy_set_header Connection "upgrade";
         chunked_transfer_encoding off;
 
+        error_page 502 = @app_proxy_init_error;
+
         proxy_pass {{ index (get .Values.routing "app-proxy") "internalUrl" }};
+      }
+
+      location @app_proxy_init_error {
+        internal;
+
+        if ($request_method = OPTIONS) {
+          add_header 'Access-Control-Allow-Origin' "{{ .Values.app-proxy.config.cors }}" always;
+          add_header 'Access-Control-Allow-Methods' 'GET,HEAD,PUT,PATCH,POST,DELETE' always;
+          add_header 'Access-Control-Allow-Headers' 'content-type,x-access-token' always;
+          add_header 'Access-Control-Allow-Credentials' 'true' always;
+          add_header 'Content-Length' 0;
+          return 204;
+        }
+
+        add_header 'Access-Control-Allow-Origin' "{{ .Values.app-proxy.config.cors }}" always;
+        add_header 'Access-Control-Allow-Methods' 'GET,HEAD,PUT,PATCH,POST,DELETE' always;
+        add_header 'Access-Control-Allow-Headers' 'content-type,x-access-token' always;
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+        return 502;
+
       }
 
       {{- if .Values.routing.workflows.enabled }}


### PR DESCRIPTION
## What
This PR updates the internal-router ConfigMap to add CORS headers in the NGINX error handler for /app-proxy.

## Why
To allow frontend clients (local.codefresh.io) to receive valid CORS responses even when the backend service is down (502). This avoids CORS-related failures on network errors during preflight or API calls.

## Notes
- CORS headers are only applied on error responses via the @app_proxy_init_error location block.
- Regular (successful) responses remain untouched.
- Preflight OPTIONS requests now return a 204 with appropriate CORS headers.