### PR TITLE
chore: bump gitops-operator 0.7.8

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.7.3
+  version: 0.7.8
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: garage


### PR DESCRIPTION
## What
 bump gitops-operator 0.7.8

## Related
- https://github.com/codefresh-io/codefresh-gitops-operator/pull/180

