### PR TITLE
chore(app-proxy): add ServiceMonitor configuration for metrics monitoring

### DIFF
--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/_deployment.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/_deployment.yaml
@@ -57,6 +57,8 @@ spec:
         ports:
         - name: http
           containerPort: 8080
+        - name: http-metrics
+          containerPort: 9100
         readinessProbe:
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/_service.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/_service.yaml
@@ -13,7 +13,7 @@ spec:
       protocol: TCP
       name: http
     - port: 9100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
       name: http-metrics
   selector:

--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/_service.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/_service.yaml
@@ -12,6 +12,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: 9100
+      targetPort: http
+      protocol: TCP
+      name: http-metrics
   selector:
     {{- include "cap-app-proxy.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/_servicemonitor.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/_servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- define "cap-app-proxy.resources.serviceMonitor" }}
+  {{- if .Values.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ default (include "cap-app-proxy.fullname" .) .Values.serviceMonitor.name }}
+  labels:
+    {{- include "cap-app-proxy.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cap-app-proxy.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http-metrics
+      interval: 30s
+      path: /metrics
+  {{- end }}
+{{- end }}

--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/_servicemonitor.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/_servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- define "cap-app-proxy.resources.serviceMonitor" }}
-  {{- if .Values.serviceMonitor.create }}
+  {{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/gitops-runtime/templates/app-proxy/servicemonitor.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/servicemonitor.yaml
@@ -1,0 +1,4 @@
+{{- $appProxyContext := deepCopy . }}
+{{- $_ := set $appProxyContext "Values" (deepCopy (get .Values "app-proxy")) }}
+{{- $_ := set $appProxyContext.Values "global" (deepCopy (get .Values "global")) }}
+{{- include "cap-app-proxy.resources.serviceMonitor" $appProxyContext }}

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -592,6 +592,11 @@ app-proxy:
     annotations: {}
     name: "cap-app-proxy"
 
+  serviceMonitor:
+    create: true
+    name: ''
+    labels: {}
+
   podAnnotations: {}
 
   podLabels: {}

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -593,7 +593,7 @@ app-proxy:
     name: "cap-app-proxy"
 
   serviceMonitor:
-    create: true
+    enabled: false
     name: ''
     labels: {}
 


### PR DESCRIPTION
Add ServiceMonitor resource definition to enable monitoring of the app-proxy's http-metrics endpoint. This change allows for better observability and performance tracking of the service.

## What

## Why

## Notes
<!-- Add any notes here -->