### PR TITLE
fix: event-reporter invalid redis-ha url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ output
 .devcontainer
 
 # ignore local dev
-values-dev.yaml
+values-dev*
 dry-run.yaml
 .debug

--- a/charts/gitops-runtime/templates/event-reporter.yaml
+++ b/charts/gitops-runtime/templates/event-reporter.yaml
@@ -1,10 +1,10 @@
 {{- $cfArgoCdExtrasContext := (index .Subcharts "cf-argocd-extras")}}
+
+{{- $_ := set (index $cfArgoCdExtrasContext.Values.eventReporter.configMaps "cmd-params-cm" "data") "argocd.server" (include "codefresh-gitops-runtime.argocd.server.no-protocol-url" . ) }}
+{{- $_ := set (index $cfArgoCdExtrasContext.Values.eventReporter.configMaps "cmd-params-cm" "data") "redis.server" (include "codefresh-gitops-runtime.argocd.redis.url" . ) }}
+{{- $_ := set (index $cfArgoCdExtrasContext.Values.eventReporter.configMaps "cmd-params-cm" "data") "repo.server" (include "codefresh-gitops-runtime.argocd.reposerver.url" . ) }}
+
 {{- if not (index .Values "argo-cd" "enabled") }}
-
-  {{- $_ := set (index $cfArgoCdExtrasContext.Values.eventReporter.configMaps "cmd-params-cm" "data") "argocd.server" (include "codefresh-gitops-runtime.argocd.server.no-protocol-url" . ) }}
-  {{- $_ := set (index $cfArgoCdExtrasContext.Values.eventReporter.configMaps "cmd-params-cm" "data") "redis.server" (include "codefresh-gitops-runtime.argocd.redis.url" . ) }}
-  {{- $_ := set (index $cfArgoCdExtrasContext.Values.eventReporter.configMaps "cmd-params-cm" "data") "repo.server" (include "codefresh-gitops-runtime.argocd.reposerver.url" . ) }}
-
   {{- if and (eq (index .Values "global" "external-argo-cd" "auth" "type") "token") }}
     {{- if not (index .Values "global" "external-argo-cd" "auth" "token") }}
         {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_NAME" (required ".Values.global.external-argo-cd.auth.type is set to 'token' therefore .Values.global.external-argo-cd.auth.tokenSecretKeyRef.name is required" (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "name")) }}

--- a/charts/gitops-runtime/templates/event-reporter.yaml
+++ b/charts/gitops-runtime/templates/event-reporter.yaml
@@ -4,20 +4,18 @@
 {{- $_ := set (index $cfArgoCdExtrasContext.Values.eventReporter.configMaps "cmd-params-cm" "data") "redis.server" (include "codefresh-gitops-runtime.argocd.redis.url" . ) }}
 {{- $_ := set (index $cfArgoCdExtrasContext.Values.eventReporter.configMaps "cmd-params-cm" "data") "repo.server" (include "codefresh-gitops-runtime.argocd.reposerver.url" . ) }}
 
-{{- if not (index .Values "argo-cd" "enabled") }}
-  {{- if and (eq (index .Values "global" "external-argo-cd" "auth" "type") "token") }}
-    {{- if not (index .Values "global" "external-argo-cd" "auth" "token") }}
-        {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_NAME" (required ".Values.global.external-argo-cd.auth.type is set to 'token' therefore .Values.global.external-argo-cd.auth.tokenSecretKeyRef.name is required" (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "name")) }}
-        {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_KEY" (required ".Values.global.external-argo-cd.auth.type is set to 'token' therefore .Values.global.external-argo-cd.auth.tokenSecretKeyRef.key is required" (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "key" )) }}
-    {{- else }}
-        {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_NAME" "gitops-runtime-argo-cd-token" }}
-        {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_KEY" "token" }}
-    {{- end }}
+{{- if and (eq (index .Values "global" "external-argo-cd" "auth" "type") "token") }}
+  {{- if not (index .Values "global" "external-argo-cd" "auth" "token") }}
+      {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_NAME" (required ".Values.global.external-argo-cd.auth.type is set to 'token' therefore .Values.global.external-argo-cd.auth.tokenSecretKeyRef.name is required" (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "name")) }}
+      {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_KEY" (required ".Values.global.external-argo-cd.auth.type is set to 'token' therefore .Values.global.external-argo-cd.auth.tokenSecretKeyRef.key is required" (index .Values "global" "external-argo-cd" "auth" "tokenSecretKeyRef" "key" )) }}
+  {{- else }}
+      {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_NAME" "gitops-runtime-argo-cd-token" }}
+      {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGO_CD_TOKEN_SECRET_KEY" "token" }}
   {{- end }}
-
-  {{- if and (index .Values "global" "external-argo-cd" "server" "rootpath") }}
-    {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGOCD_SERVER_ROOTPATH" (index .Values "global" "external-argo-cd" "server" "rootpath") }}
-  {{- end }}
-
 {{- end }}
+
+{{- if and (index .Values "global" "external-argo-cd" "server" "rootpath") }}
+  {{- $_ := set $cfArgoCdExtrasContext.Values.eventReporter.container.env "ARGOCD_SERVER_ROOTPATH" (index .Values "global" "external-argo-cd" "server" "rootpath") }}
+{{- end }}
+
 {{ include "cf-argocd-extras.event-reporter.resources" $cfArgoCdExtrasContext }}

--- a/charts/gitops-runtime/tests/cf-argocd-extras_test.yaml
+++ b/charts/gitops-runtime/tests/cf-argocd-extras_test.yaml
@@ -138,3 +138,19 @@ tests:
       - equal:
           path: data["redis.server"]
           value: RELEASE-NAME-redis-ha-haproxy:6379
+
+  - it: Event-Reporter ConfigMap should have valid redis-ha url
+    template: event-reporter.yaml
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    values:
+      - ./values/mandatory-values-ingress.yaml
+    set:
+      argo-cd:
+        redis-ha:
+          enabled: true
+    asserts:
+      - equal:
+          path: data["redis.server"]
+          value: RELEASE-NAME-redis-ha-haproxy:6379


### PR DESCRIPTION
## What

Event-reporter should use correct redis svc address when redis HA is enabled

```yaml
gitops-runtime:
  global:
    ...
  argo-cd:
    redis-ha:
      enabled: true
 ```     

## Why

## Notes
<!-- Add any notes here -->