### PR TITLE
feat: bumped argocd chart to 7.8.23-9-cap-v2.14.9-2025-06-08-8821b48e

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
   condition: argo-cd.enabled
-  version: 7.8.23-7-cap-v2.14.9-2025-05-29-397c4f0d
+  version: 7.8.23-9-cap-v2.14.9-2025-06-08-8821b48e
 - name: argo-events
   repository: https://codefresh-io.github.io/argo-helm
   version: 2.4.7-2-cap-CR-28072


### PR DESCRIPTION
## What
bump argo cd to v2.14.9-2025-06-08-8821b48e bumped x/crypto to 0.35.0, bumped go to 1.23.0
https://github.com/codefresh-io/argo-helm/pull/175
bump redis to 7.4.4 dex to 2.43.1 redis-ha chart to 4.33.4
https://github.com/codefresh-io/argo-helm/pull/174
## Why

## Notes
<!-- Add any notes here -->