### PR TITLE
chore: test to see if this version causes a bug in workflow events

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -116,7 +116,7 @@ dependencies:
     version: 2.4.7-2-cap-CR-28072
   - name: argo-workflows
     repository: https://codefresh-io.github.io/argo-helm
-    version: 0.45.15-v3.6.7-cap-CR-28355
+    version: 0.45.4-v3.6.4-cap-CR-27392
     condition: argo-workflows.enabled
   - name: argo-rollouts
     repository: https://codefresh-io.github.io/argo-helm


### PR DESCRIPTION
Change the ConfigMap name from a variable to the actual name 'argocd-cmd-params-cm'
in the validate-values.yaml script to ensure correct fetching of the root path.
This improves clarity and prevents potential issues with undefined variables.## What

## Why

## Notes
<!-- Add any notes here -->