### PR TITLE
chore: bump gitops operator to v0.7.18

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: v0.7.18
+  version: 0.7.18
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: cf-argocd-extras


### PR DESCRIPTION
## Gitops Operator Changes:

- https://github.com/codefresh-io/codefresh-gitops-operator/issues/186
- https://github.com/codefresh-io/codefresh-gitops-operator/issues/192