### PR TITLE
chore: bump app-proxy image tags to 1.3591.0 - fix memory consumption and duration issues during git operations

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -545,7 +545,7 @@ app-proxy:
           tag: 1.1.13-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3584.0
+    tag: 1.3591.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -553,7 +553,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3584.0
+      tag: 1.3591.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
bump app-proxy image tags to 1.3591.0

## Why
fix memory consumption and duration issues during git operations
replace isomorphic-git with simple-git

## Notes
<!-- Add any notes here -->