### PR TITLE
chore: bump codefresh-gitops-operator version to 0.7.22

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.7.20
+  version: 0.7.22
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: cf-argocd-extras


### PR DESCRIPTION
## What
 bump codefresh-gitops-operator version to 0.7.22
## Why
security vulnerability fix
## Notes
<!-- Add any notes here -->