### PR TITLE
chore: update app-proxy image tags to 1.3600.0 - fix check for pull-merge

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -545,7 +545,7 @@ app-proxy:
           tag: 1.1.13-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3591.0
+    tag: 1.3600.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -553,7 +553,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3591.0
+      tag: 1.3600.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
new app-proxy correctly pull-merges when needed

## Why
previous app-proxy switch from isomorphic-git to simple-git had an wrong check for when to perform a pull-merge when push failed.

## Notes
<!-- Add any notes here -->