### PR TITLE
fix: bump gitops operator to v0.7.24

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.7.22
+  version: 0.7.24
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: cf-argocd-extras


### PR DESCRIPTION
## What
fixes: https://github.com/codefresh-io/codefresh-gitops-operator/pull/201