### PR TITLE
chore: removed unused env var in app-proxy

### DIFF
--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/environment-variables/_main-container.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/environment-variables/_main-container.yaml
@@ -211,6 +211,7 @@ IRW_JIRA_ENRICHMENT_TASK_IMAGE:
       key: enrichmentJiraEnrichmentImage
       optional: true
 NODE_EXTRA_CA_CERTS: /app/config/all/all.cer
+GIT_SSL_CAINFO: /app/config/all/all.cer
 {{- end -}}
 
 {{/*

--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/environment-variables/_main-container.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/environment-variables/_main-container.yaml
@@ -211,7 +211,6 @@ IRW_JIRA_ENRICHMENT_TASK_IMAGE:
       key: enrichmentJiraEnrichmentImage
       optional: true
 NODE_EXTRA_CA_CERTS: /app/config/all/all.cer
-GIT_SSL_CAINFO: /app/config/all/all.cer
 {{- end -}}
 
 {{/*

--- a/charts/gitops-runtime/templates/app-proxy/_app-proxy-env.yaml
+++ b/charts/gitops-runtime/templates/app-proxy/_app-proxy-env.yaml
@@ -12,7 +12,6 @@ GIT_USERNAME: {{ .Values.global.runtime.gitCredentials.username }}
 GIT_PASSWORD:
   {{- include "codefresh-gitops-runtime.runtime-gitcreds.password.env-var-value" . | nindent 2 }}
   {{- end }}
-WORKFLOW_PIPELINES_WEBHOOKS_TLS_SECRET: codefresh-workflow-pipelines-tls
 {{- /* Target account id, used for hosted runtimes registration. Not used in hybrid */}}
   {{- if .Values.global.runtime.codefreshHosted }}
 INSTALLATION_TYPE: HELM_HOSTED


### PR DESCRIPTION
## What
app-proxy will send current env vars to simple-git execution
added GIT_SSAL_CAINFO to let git binary access self-signed servers

## Why
on-prem git servers with self-signed certificates would fail cloning.

## Notes
<!-- Add any notes here -->