### PR TITLE
chore(CR-29827): upd cli-v2 for installer

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
 - name: argo-cd
   repository: https://codefresh-io.github.io/argo-helm
   condition: argo-cd.enabled
-  version: 8.0.6-3-cap-v3.0.2-2025-06-24-979b8c8e
+  version: 8.0.6-4-cap-v3.0.2-2025-07-06-e9fc72a9
 - name: argo-events
   repository: https://codefresh-io.github.io/argo-helm
   version: 2.4.8-cap-CR-29689
@@ -44,4 +44,4 @@ dependencies:
   condition: gitops-operator.enabled
 - name: cf-argocd-extras
   repository: oci://quay.io/codefresh/charts
-  version: 0.5.6
+  version: 0.5.7

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -545,7 +545,7 @@ app-proxy:
           tag: 1.1.14-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3600.0
+    tag: 1.3628.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -553,7 +553,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3600.0
+      tag: 1.3628.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
CVE-2025-47933 fixed by updating github.com/argoproj/argo-cd/v2 in cli-v2
CVE-2025-22868 fixed by updating golang.org/x/oauth2/jws in cli-v2
## Why

## Notes
<!-- Add any notes here -->