### PR TITLE
fix: update REQUIRED_VERSION_CONSTRAINT for Argo CD compatibility

### DIFF
--- a/charts/gitops-runtime/templates/hooks/pre-install/_env.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-install/_env.yaml
@@ -22,7 +22,7 @@ NAMESPACE:
   valueFrom:
     fieldRef:
       fieldPath: metadata.namespace
-REQUIRED_VERSION_CONSTRAINT: ">=2.12 <3"
+REQUIRED_VERSION_CONSTRAINT: ">=2.12 <3.1"
 {{- end -}}
 
 {{- define "installer.validate-values.environment-variables" -}}


### PR DESCRIPTION
Adjust the REQUIRED_VERSION_CONSTRAINT in the validate-values.yaml
to ensure compatibility with Argo CD versions, allowing for versions
up to but not including 3.1.

## What

## Why

## Notes
<!-- Add any notes here -->