### PR TITLE
chore: upgrade gitops operator

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -54,7 +54,7 @@ dependencies:
     condition: tunnel-client.enabled
   - name: codefresh-gitops-operator
     repository: oci://quay.io/codefresh/charts
-    version: 0.8.0
+    version: 0.8.2
     alias: gitops-operator
     condition: gitops-operator.enabled
   - name: cf-argocd-extras


### PR DESCRIPTION
## What
This reverts commit https://github.com/codefresh-io/codefresh-gitops-operator/commit/979dad5d42d0f466514bc0aa68605d3726cae37e.
## Why
The impl was getting product on the cluster, which will not be exist on runtime that are not configuration runtimes
## Notes
<!-- Add any notes here -->