### PR TITLE
chore: bump gitops operator

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -29,34 +29,34 @@ annotations:
     - kind: changed
       description: 'sec: security upd nats exporter (#543)'
 dependencies:
-  - name: argo-cd
-    repository: https://codefresh-io.github.io/argo-helm
-    condition: argo-cd.enabled
-    version: 8.0.6-4-cap-v3.0.2-2025-07-06-e9fc72a9
-  - name: argo-events
-    repository: https://codefresh-io.github.io/argo-helm
-    version: 2.4.8-cap-CR-29689
-  - name: argo-workflows
-    repository: https://codefresh-io.github.io/argo-helm
-    version: 0.45.15-v3.6.7-cap-CR-28355
-    condition: argo-workflows.enabled
-  - name: argo-rollouts
-    repository: https://codefresh-io.github.io/argo-helm
-    version: 2.37.3-5-v1.7.2-cap-CR-29629
-    condition: argo-rollouts.enabled
-  - name: sealed-secrets
-    repository: https://bitnami-labs.github.io/sealed-secrets/
-    version: 2.17.2
-  - name: codefresh-tunnel-client
-    repository: oci://quay.io/codefresh/charts
-    version: 0.1.21
-    alias: tunnel-client
-    condition: tunnel-client.enabled
-  - name: codefresh-gitops-operator
-    repository: oci://quay.io/codefresh/charts
-    version: 0.8.0
-    alias: gitops-operator
-    condition: gitops-operator.enabled
-  - name: cf-argocd-extras
-    repository: oci://quay.io/codefresh/charts
-    version: 0.5.7
+- name: argo-cd
+  repository: https://codefresh-io.github.io/argo-helm
+  condition: argo-cd.enabled
+  version: 8.0.6-4-cap-v3.0.2-2025-07-06-e9fc72a9
+- name: argo-events
+  repository: https://codefresh-io.github.io/argo-helm
+  version: 2.4.8-cap-CR-29689
+- name: argo-workflows
+  repository: https://codefresh-io.github.io/argo-helm
+  version: 0.45.15-v3.6.7-cap-CR-28355
+  condition: argo-workflows.enabled
+- name: argo-rollouts
+  repository: https://codefresh-io.github.io/argo-helm
+  version: 2.37.3-5-v1.7.2-cap-CR-29629
+  condition: argo-rollouts.enabled
+- name: sealed-secrets
+  repository: https://bitnami-labs.github.io/sealed-secrets/
+  version: 2.17.2
+- name: codefresh-tunnel-client
+  repository: oci://quay.io/codefresh/charts
+  version: 0.1.21
+  alias: tunnel-client
+  condition: tunnel-client.enabled
+- name: codefresh-gitops-operator
+  repository: oci://quay.io/codefresh/charts
+  version: 0.8.2
+  alias: gitops-operator
+  condition: gitops-operator.enabled
+- name: cf-argocd-extras
+  repository: oci://quay.io/codefresh/charts
+  version: 0.5.7


### PR DESCRIPTION
## What
This reverts commit https://github.com/codefresh-io/codefresh-gitops-operator/commit/979dad5d42d0f466514bc0aa68605d3726cae37e.
## Why
The impl was getting product on the cluster, which will not be exist on runtime that are not configuration runtimes
## Notes
<!-- Add any notes here -->