### PR TITLE
chore: update codefresh-gitops-operator version to 0.8.4

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.8.2
+  version: 0.8.4
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: cf-argocd-extras


### PR DESCRIPTION
## What
stop attempting to resume a non-running workflow

## Why
without that change, the gitops-operator might go into a long-running loop of attempting to resume a terminated workflow, until it will be garbage-collected by the cluster (defaults to 2h). this will also block any other application reconciliation during that time.

## Notes
<!-- Add any notes here -->