### PR TITLE
chore: update gitops operator to 0.8.5

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   condition: tunnel-client.enabled
 - name: codefresh-gitops-operator
   repository: oci://quay.io/codefresh/charts
-  version: 0.8.4
+  version: 0.8.5
   alias: gitops-operator
   condition: gitops-operator.enabled
 - name: cf-argocd-extras


### PR DESCRIPTION
## Details
Gitops Operator change: https://github.com/codefresh-io/codefresh-gitops-operator/pull/216

We are updating the look-back time period to 2 hours to make the operator work better specifically for Spare in the short term. We have another ticket (https://codefresh-io.atlassian.net/browse/CR-29944) to fix this area of the code so that resume workflows will work no matter how long ago a commit was made.