### PR TITLE
chore: bump app proxy to revert cf-git-provider that had error handli…

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -552,7 +552,7 @@ app-proxy:
           tag: 1.1.14-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3636.0
+    tag: 1.3636.0-6119302
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -560,7 +560,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3636.0
+      tag: 1.3636.0-6119302
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
…ng issue

## What
revert cf-git-providers to 0.14.3
## Why
cf-git-provider 0.15.1 was causing error that made app proxy to crush on some edge case
## Notes
<!-- Add any notes here -->