### PR TITLE
chore: update app-proxy image tags to 1.3651.0

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -570,7 +570,7 @@ app-proxy:
           tag: 1.1.14-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3642.0
+    tag: 1.3651.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
@@ -578,7 +578,7 @@ app-proxy:
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3642.0
+      tag: 1.3651.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
* fix(dependencies): update cf-git-providers to version ^0.15.2 ([#6528](https://github.com/codefresh-io/argo-platform/pull/6528))
  * fix: unhandledRejection when getting rate-limit error on github api calls ([#6528](https://github.com/codefresh-io/argo-platform/pull/6528))

## Why
[CR-30068](https://codefresh-io.atlassian.net/browse/CR-30068)

## Notes
<!-- Add any notes here -->

[CR-30068]: https://codefresh-io.atlassian.net/browse/CR-30068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ