### PR TITLE
fix: update eventbus type to jetstream in values.yaml

### DIFF
--- a/charts/gitops-runtime/tests/eventbus_test.yaml
+++ b/charts/gitops-runtime/tests/eventbus_test.yaml
@@ -39,7 +39,7 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: codefresh-eventbus
+          value: codefresh-eventbus-jetstream
 
   - it: Should create an EventBus with the correct override name (nats)
     template: eventbus/codefresh-eventbus.yaml

--- a/charts/gitops-runtime/tests/eventbus_test.yaml
+++ b/charts/gitops-runtime/tests/eventbus_test.yaml
@@ -30,12 +30,12 @@ tests:
       - notExists:
           path: spec.nats
 
-  - it: Should create an EventBus with the correct default name (nats)
+  - it: Should create an EventBus with the correct default name (jetstream)
     template: eventbus/codefresh-eventbus.yaml
     values:
       - ./values/mandatory-values.yaml
     set:
-      global.runtime.eventBus.type: nats
+      global.runtime.eventBus.type: jetstream
     asserts:
       - equal:
           path: metadata.name

--- a/charts/gitops-runtime/tests/global_constraints_test.yaml
+++ b/charts/gitops-runtime/tests/global_constraints_test.yaml
@@ -119,13 +119,13 @@ tests:
         template: event-reporters/workflow-reporter/sensor.yaml
       # -- codefresh-eventbus
       - equal:
-          path: spec.nats.native.nodeSelector
+          path: spec.jetstream.nodeSelector
           value:
             some-key: some-value
             extra-key: extra-value
         template: eventbus/codefresh-eventbus.yaml
       - equal:
-          path: spec.nats.native.tolerations
+          path: spec.jetstream.tolerations
           value:
           - key: some-key
             operator: Equal
@@ -456,13 +456,13 @@ tests:
         template: event-reporters/workflow-reporter/sensor.yaml
       # -- codefresh-eventbus
       - equal:
-          path: spec.nats.native.nodeSelector
+          path: spec.jetstream.nodeSelector
           value:
             some-key: another-value
             foo: bar
         template: eventbus/codefresh-eventbus.yaml
       - equal:
-          path: spec.nats.native.tolerations
+          path: spec.jetstream.tolerations
           value:
             - key: another-key
               operator: Equal

--- a/charts/gitops-runtime/tests/values/subcharts-constraints-values.yaml
+++ b/charts/gitops-runtime/tests/values/subcharts-constraints-values.yaml
@@ -12,10 +12,9 @@ anchors:
 global:
   runtime:
     eventBus:
-      nats:
-        native:
-          nodeSelector: *nodeSelector
-          tolerations: *tolerations
+      jetstream:
+        nodeSelector: *nodeSelector
+        tolerations: *tolerations
 
 app-proxy:
   nodeSelector: *nodeSelector

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -89,7 +89,7 @@ global:
         enabled: true
         # -- Minimum number of available eventbus pods. For eventbus to stay functional the majority of its replicas should always be available.
         minAvailable: 2
-      type: nats # -- Eventbus type. Can be nats or jetstream.
+      type: jetstream # -- Eventbus type. Can be nats or jetstream.
       nats:
         native:
           metadata:


### PR DESCRIPTION
## What
changed default EventBus implementation to use jetstream instead of nats

## Why
much more reliable

## Notes
<!-- Add any notes here -->