### PR TITLE
chore: update cap-app-proxy image tags to 1.3680.0

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -564,14 +564,14 @@ app-proxy:
           tag: 1.1.14-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3674.0
+    tag: 1.3680.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3674.0
+      tag: 1.3680.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
fix: return the pushed commit sha [#6560](https://github.com/codefresh-io/argo-platform/pull/6560)

## Why

## Notes
<!-- Add any notes here -->