### PR TITLE
feat: solve out-of-sync crds in Argo CD v3

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   condition: argo-workflows.enabled
 - name: argo-rollouts
   repository: https://codefresh-io.github.io/argo-helm
-  version: 2.37.3-5-v1.7.2-cap-CR-29629
+  version: 2.37.3-6-v1.7.2-cap-CR-29629
   condition: argo-rollouts.enabled
 - name: sealed-secrets
   repository: https://bitnami-labs.github.io/sealed-secrets/


### PR DESCRIPTION
Argo CD v3 [shows as out-of-sync any CRDs](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.14-3.0/#removing-default-ignores-of-preserveunknownfields-for-crd) that have preserveUnknownFields: false

