### PR TITLE
chore: default app-proxy logs to have prettified logs including iso timestamps

### DIFF
--- a/charts/gitops-runtime/templates/_components/cap-app-proxy/environment-variables/_main-container.yaml
+++ b/charts/gitops-runtime/templates/_components/cap-app-proxy/environment-variables/_main-container.yaml
@@ -211,6 +211,7 @@ IRW_JIRA_ENRICHMENT_TASK_IMAGE:
       key: enrichmentJiraEnrichmentImage
       optional: true
 NODE_EXTRA_CA_CERTS: /app/config/all/all.cer
+CF_TELEMETRY_LOGS_PRETTIFY: single-line
 {{ include "codefresh-gitops-runtime.get-proxy-env-vars" . }}
 {{- end -}}
 


### PR DESCRIPTION
## Summary

By default the app-proxy logs use epoch timestamps which are really hard to grok when trying to debug problems.

This change makes the app-proxy log things in a nicer format more reasonable for humans to read.

Note: I'm still testing this to ensure that integrations will still work as expected.