### PR TITLE
fix: service account for cleanup runtime resources

### DIFF
--- a/charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml
@@ -9,7 +9,7 @@ spec:
   backoffLimit: 3
   template:
     spec:
-      serviceAccount: argocd-application-controller
+      serviceAccount: runtime-cleanup
       restartPolicy: Never
       containers:
       - name: cleanup-runtime-resources


### PR DESCRIPTION
## What

This pull request makes a minor update to the `cleanup-resources.yaml` hook template by changing the `serviceAccount` used for the cleanup job. The new service account, `runtime-cleanup`, is likely more appropriate for the job's permissions and responsibilities.

- Changed the `serviceAccount` in the `charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml` file from `argocd-application-controller` to `runtime-cleanup` to better align with the job's purpose.

## Why


```
Error creating: pods "cleanup-runtime-resources-" is forbidden: error looking up service account codefresh-gitops/argocd-application-controller: serviceaccount "argocd-application-controller" not found 
```
> `codefresh-gitops` mentioned in the error message above refers to a namespace.

## Notes

Use case: leveraging the `gitops-runtime` chart for the deployment of `argo-rollouts` components within Managed Clusters. In this context, I disable nearly all Codefresh GitOps Runtime components in the `values.yaml` (including the argo-cd dependency, which is the reason the Argo Application Controller is absent) to focus exclusively on the `argo-rollouts` components (Argo Rollouts and its Event Reporter) on Managed Clusters connected to the Runtime.