### PR TITLE
quote proxy env vars

### DIFF
--- a/charts/gitops-runtime/templates/_helpers.tpl
+++ b/charts/gitops-runtime/templates/_helpers.tpl
@@ -513,13 +513,13 @@ Print proxy environment variables
 */}}
 {{- define "codefresh-gitops-runtime.get-proxy-env-vars" -}}
   {{- if .Values.global.httpProxy }}
-HTTP_PROXY: {{ .Values.global.httpProxy }}
+HTTP_PROXY: {{ .Values.global.httpProxy | quote }}
   {{- end }}
   {{- if .Values.global.httpsProxy }}
-HTTPS_PROXY: {{ .Values.global.httpsProxy }}
+HTTPS_PROXY: {{ .Values.global.httpsProxy | quote }}
   {{- end }}
   {{- if .Values.global.noProxy }}
-NO_PROXY: {{ .Values.global.noProxy }}
+NO_PROXY: {{ .Values.global.noProxy | quote }}
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
## What
without the quote, using `*.some.domain` in `global.noProxy` would mess up all the env variables of the app-proxy.

## Why

## Notes
<!-- Add any notes here -->