### PR TITLE
fix: Updated gitops operator not to requeue on known release creation failures

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -726,7 +726,7 @@ gitops-operator:
     # -- defaults
     registry: quay.io
     repository: codefresh/codefresh-gitops-operator
-    tag: v0.10.0
+    tag: v0.10.1
   serviceAccount:
     create: true
     annotations: {}


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->