### PR TITLE
chore(app-proxy): update cap-app-proxy image tags to 1.3702.0

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -564,14 +564,14 @@ app-proxy:
           tag: 1.1.15-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3701.0
+    tag: 1.3702.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3701.0
+      tag: 1.3702.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
fix: "cannot lock ref" error while performing a promotion ([6593](https://github.com/codefresh-io/argo-platform/pull/6593))

## Why

## Notes
<!-- Add any notes here -->