### PR TITLE
feat: update cap-app-proxy image tags to 1.3750.0

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -564,14 +564,14 @@ app-proxy:
           tag: 1.1.15-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
-    tag: 1.3735.0
+    tag: 1.3750.0
     pullPolicy: IfNotPresent
   # -- Extra volume mounts for main container
   extraVolumeMounts: []
   initContainer:
     image:
       repository: quay.io/codefresh/cap-app-proxy-init
-      tag: 1.3735.0
+      tag: 1.3750.0
       pullPolicy: IfNotPresent
     command:
       - ./init.sh


### PR DESCRIPTION
## What
update cap-app-proxy image tags to 1.3750.0

## Why
fix preview of promotion properties ([#6661](https://github.com/codefresh-io/argo-platform/pull/6661))

## Notes
<!-- Add any notes here -->