### PR TITLE
fix: service account for cleanup runtime resources

### DIFF
--- a/charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml
@@ -9,7 +9,7 @@ spec:
   backoffLimit: 3
   template:
     spec:
-      serviceAccount: argocd-application-controller
+      serviceAccount: runtime-cleanup
       restartPolicy: Never
       containers:
       - name: cleanup-runtime-resources

--- a/charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cleanup-runtime-resources
   annotations:
     helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:
   backoffLimit: 3

--- a/charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml
@@ -3,8 +3,8 @@ kind: Job
 metadata:
   name: cleanup-runtime-resources
   annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:
   backoffLimit: 3
   template:

--- a/charts/gitops-runtime/templates/hooks/pre-uninstall/delete-runtime-from-platform.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-uninstall/delete-runtime-from-platform.yaml
@@ -8,8 +8,9 @@ kind: Job
 metadata:
   name: delete-runtime-from-platform
   annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
 spec:
   backoffLimit: 3
   template:

--- a/charts/gitops-runtime/templates/hooks/pre-uninstall/delete-runtime-from-platform.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-uninstall/delete-runtime-from-platform.yaml
@@ -9,7 +9,6 @@ metadata:
   name: delete-runtime-from-platform
   annotations:
     helm.sh/hook: pre-delete
-    helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
 spec:
   backoffLimit: 3

--- a/charts/gitops-runtime/templates/hooks/pre-uninstall/rbac.yaml
+++ b/charts/gitops-runtime/templates/hooks/pre-uninstall/rbac.yaml
@@ -1,10 +1,20 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: runtime-cleanup
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: runtime-cleanup
   annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
 rules:
   - apiGroups:
       - "*"
@@ -18,8 +28,9 @@ kind: RoleBinding
 metadata:
   name: runtime-cleanup
   annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
 roleRef:
   apiGroup: ""
   kind: Role
@@ -27,11 +38,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: runtime-cleanup
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: runtime-cleanup
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed


### PR DESCRIPTION
re-open of #642

## What

This pull request makes a minor update to the `cleanup-resources.yaml` hook template by changing the `serviceAccount` used for the cleanup job. The new service account, `runtime-cleanup`, is likely more appropriate for the job's permissions and responsibilities.

- Changed the `serviceAccount` in the `charts/gitops-runtime/templates/hooks/pre-uninstall/cleanup-resources.yaml` file from `argocd-application-controller` to `runtime-cleanup` to better align with the job's purpose.

## Why


```
Error creating: pods "cleanup-runtime-resources-" is forbidden: error looking up service account codefresh-gitops/argocd-application-controller: serviceaccount "argocd-application-controller" not found 
```
> `codefresh-gitops` mentioned in the error message above refers to a namespace.

## Notes

Use case: leveraging the `gitops-runtime` chart for the deployment of `argo-rollouts` components within Managed Clusters. In this context, I disable nearly all Codefresh GitOps Runtime components in the `values.yaml` (including the argo-cd dependency, which is the reason the Argo Application Controller is absent) to focus exclusively on the `argo-rollouts` components (Argo Rollouts and its Event Reporter) on Managed Clusters connected to the Runtime.