### PR TITLE
fix: promotion values can't be empty

### DIFF
--- a/charts/gitops-runtime/templates/_components/gitops-operator/crds/promotiontasks.yaml
+++ b/charts/gitops-runtime/templates/_components/gitops-operator/crds/promotiontasks.yaml
@@ -155,7 +155,6 @@ spec:
                                       minLength: 1
                                       type: string
                                     value:
-                                      minLength: 1
                                       type: string
                                   required:
                                   - path
@@ -212,7 +211,6 @@ spec:
                                       minLength: 1
                                       type: string
                                     value:
-                                      minLength: 1
                                       type: string
                                   required:
                                   - path
@@ -416,7 +414,6 @@ spec:
                                       minLength: 1
                                       type: string
                                     value:
-                                      minLength: 1
                                       type: string
                                   required:
                                   - path

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -156,7 +156,6 @@ global:
           # tokenSecretKeyRef:
           #   name: argocd-token
           #   key: token
-
   # -- Configuration for external ArgoCD
   # Should be used when `argo-cd.enabled` is set to false
   external-argo-cd:
@@ -180,7 +179,6 @@ global:
       svc: argocd-repo-server
       # -- Port of the ArgoCD repo server
       port: 8081
-
   # -- Configuration for external Argo Rollouts
   external-argo-rollouts:
     # -- Rollout reporter settings
@@ -730,7 +728,7 @@ gitops-operator:
     # -- defaults
     registry: quay.io
     repository: codefresh/codefresh-gitops-operator
-    tag: 8bd2a64
+    tag: 266564a
   env:
     GITOPS_OPERATOR_VERSION: 0.11.1
   serviceAccount:


### PR DESCRIPTION
## What
Related Operator PR: https://github.com/codefresh-io/codefresh-gitops-operator/pull/287