### PR TITLE
fix: bump Gitops Operator to functional version with security patches

### DIFF
--- a/.github/workflows/component-test.yaml
+++ b/.github/workflows/component-test.yaml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   component-test:
-    if : false # temporarily disable component tests
     runs-on: ubuntu-latest
 
     env:

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -646,8 +646,8 @@ gitops-operator:
   # -- GitOps operator image
   image:
     registry: quay.io
-    repository: codefresh/codefresh-gitops-operator
-    tag: b9540c4
+    repository: codefresh/dev/codefresh-gitops-operator
+    tag: chore-cr-33112-update-argocd-security-fix-take-2-dd015d7
   env:
     !!merge <<:
       - *otel-config


### PR DESCRIPTION
## What
Bumping Gitops Operator for correct working version so that promotions work correctly.

## Why
See Gitops Operator PR for full details

## Notes
Gitops Operator PR: https://github.com/codefresh-io/codefresh-gitops-operator/pull/378