### PR TITLE
chore: security fix

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.2.3
 description: A Helm chart for Codefresh gitops runtime
 name: gitops-runtime
-version: 0.29.2
+version: 0.29.3
 home: https://github.com/codefresh-io/gitops-runtime-helm
 icon: https://avatars1.githubusercontent.com/u/11412079?v=3
 keywords:

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -136,7 +136,7 @@ global:
     image:
       registry: quay.io
       repository: codefresh/cf-argocd-extras
-      tag: "3190219"
+      tag: "06801ec"
     nodeSelector: {}
     tolerations: []
     affinity: {}
@@ -679,7 +679,7 @@ argo-gateway:
   image:
     registry: quay.io
     repository: codefresh/cf-argocd-extras
-    tag: "3190219"
+    tag: "06801ec"
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 
-FROM octopusdeploy/dhi-golang:1.25-debian13-dev AS build
+# DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-golang/tags/1.25-debian13-dev
+FROM octopusdeploy/dhi-golang:1.25-debian13-dev@sha256:b2c03c829a4df4f724712501d18321e46a2ac770377f0b6e2f383bc9d02b99d3 AS build
 ARG TARGETARCH
 ARG CF_CLI_VERSION=v1.0.2
 RUN go install github.com/davidrjonas/semver-cli@latest \
@@ -9,7 +10,7 @@ ADD --unpack=true --chown=nonroot:nonroot --chmod=755 https://github.com/codefre
 
 
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-debian-base/customizations/8106437942896324135
-FROM octopusdeploy/dhi-debian-base:trixie_cf-gitops-runtime-installer-debian13@sha256:e72836b4e4c408f04caf8ac6e34824d90e192b7cecedab9aeed647e14d0cd599 AS production
+FROM octopusdeploy/dhi-debian-base:trixie_cf-gitops-runtime-installer-debian13@sha256:ab35aedc53ad95d3a95094d6f2c9d052c2cdb43b605ce1f9a4ea677911373b99 AS production
 ARG TARGETARCH
 COPY --from=build --chown=nonroot:nonroot --chmod=755 /tmp/cf/cf-linux-${TARGETARCH} /usr/local/bin/cf
 COPY --from=build --chown=nonroot:nonroot --chmod=755 /tmp/semver-cli /usr/local/bin/semver-cli


### PR DESCRIPTION
CVE-2026-34165, CVE-2026-25934, CVE-2026-33762
(github.com/go-git/go-git/v5)
fix high vulnerabilities in glibc, dpkg

## What

## Why

## Notes
<!-- Add any notes here -->