### PR TITLE
fix: runtime redis ha selectors coincide with ones used for argo-cd components

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -831,6 +831,8 @@ redis-ha:
   enabled: false
   # -- Full name of the Redis HA Resources
   fullnameOverride: "runtime-redis-ha"
+  # -- Name of the Redis HA Resources used for selectors
+  nameOverride: runtime-redis
   ## Redis image
   image:
     # -- Redis repository


### PR DESCRIPTION
## What

## Why

<img width="891" height="507" alt="image" src="https://github.com/user-attachments/assets/81869d8a-b42f-4b38-b0da-5d1e641c11dc" />


## Notes
<!-- Add any notes here -->