### PR TITLE
chore: bump enrichers to 1.1.26-main with security fixes

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -446,17 +446,17 @@ app-proxy:
         reportImage:
           registry: quay.io
           repository: codefreshplugins/argo-hub-codefresh-csdp-report-image-info
-          tag: 1.1.25-main
+          tag: 1.1.26-main
         # Git enrichment task image
         gitEnrichment:
           registry: quay.io
           repository: codefreshplugins/argo-hub-codefresh-csdp-image-enricher-git-info
-          tag: 1.1.25-main
+          tag: 1.1.26-main
         # Jira enrichment task image
         jiraEnrichment:
           registry: quay.io
           repository: codefreshplugins/argo-hub-codefresh-csdp-image-enricher-jira-info
-          tag: 1.1.25-main
+          tag: 1.1.26-main
   image:
     repository: quay.io/codefresh/cap-app-proxy
     tag: 1.4081.0


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->