### PR TITLE
fix: security vulnerabilities in gitops-runtime-installer

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -32,7 +32,7 @@ dependencies:
     version: 0.45.23-v3.6.7-cap-CFS-7012
     condition: argo-workflows.enabled
   - name: sealed-secrets
-    repository: https://bitnami-labs.github.io/sealed-secrets/
+    repository: https://bitnami.github.io/sealed-secrets/
     version: 2.18.0
     condition: sealed-secrets.enabled
   - name: codefresh-tunnel-client

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.2.3
 description: A Helm chart for Codefresh gitops runtime
 name: gitops-runtime
-version: 0.29.14
+version: 0.29.15
 home: https://github.com/codefresh-io/gitops-runtime-helm
 icon: https://avatars1.githubusercontent.com/u/11412079?v=3
 keywords:

--- a/installer-image/Dockerfile
+++ b/installer-image/Dockerfile
@@ -3,7 +3,7 @@
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-golang/tags/1.25-debian13-dev
 FROM octopusdeploy/dhi-golang:1.25-debian13-dev@sha256:9df1a12a7a9ee811efe2929045a7eabb8617329e8ce01a3296f4af095f89522c AS build
 ARG TARGETARCH
-ARG CF_CLI_VERSION=v1.0.3
+ARG CF_CLI_VERSION=v1.0.5
 RUN go install github.com/davidrjonas/semver-cli@latest \
   && cp $GOPATH/bin/semver-cli /tmp/semver-cli
 RUN apt-get update && apt-get install -y --no-install-recommends sed && rm -rf /var/lib/apt/lists/*
@@ -11,7 +11,7 @@ ADD --unpack=true --chown=nonroot:nonroot --chmod=755 https://github.com/codefre
 
 
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-debian-base/customizations/8106437942896324135
-FROM octopusdeploy/dhi-debian-base:trixie_cf-gitops-runtime-installer-debian13@sha256:5de4afaf8d55ff711756e2ebd9e27fc05374c37d3805acf85dfed70ef07fbee2 AS production
+FROM octopusdeploy/dhi-debian-base:trixie_cf-gitops-runtime-installer-debian13@sha256:f29cbe0661df45db3eeeac570c2c2c6dae30adfb53b9d89956d11d10699b7461 AS production
 ARG TARGETARCH
 COPY --from=build --chown=nonroot:nonroot --chmod=755 /tmp/cf/cf-linux-${TARGETARCH} /usr/local/bin/cf
 COPY --from=build --chown=nonroot:nonroot --chmod=755 /tmp/semver-cli /usr/local/bin/semver-cli


### PR DESCRIPTION
## Why
https://linear.app/octopus/issue/CFS-7340/security-or-codefreshgitops-runtime-installer-or-cve-2026-45738-orhigh