### PR TITLE
fix(internal-router): bump nginx-unprivileged for security fix

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     condition: sealed-secrets.enabled
   - name: codefresh-tunnel-client
     repository: oci://quay.io/codefresh/charts
-    version: 0.1.24
+    version: 0.1.25
     alias: tunnel-client
     condition: tunnel-client.enabled
   - name: redis-ha

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -353,7 +353,7 @@ internal-router:
   image:
     repository: docker.io/nginxinc/nginx-unprivileged
     pullPolicy: IfNotPresent
-    tag: 1.29-alpine3.23
+    tag: 1.31.2-alpine3.23
   imagePullSecrets: []
   nameOverride: ""
   fullnameOverride: "internal-router"

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -748,7 +748,7 @@ redis-secret-init:
   image:
     registry: docker.io
     repository: alpine/kubectl
-    tag: 1.35.4
+    tag: 1.36.2
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## What

fix https://linear.app/octopus/issue/CFS-11626/security-or-alpinekubectl-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-11518/security-or-codefreshfrpc-or-cve-2026-45447-or

## Why

## Notes
<!-- Add any notes here -->