### PR TITLE
fix(internal-router): bump nginx-unprivileged for security fix

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.2.3
 description: A Helm chart for Codefresh gitops runtime
 name: gitops-runtime
-version: 0.29.15
+version: 0.29.16
 home: https://github.com/codefresh-io/gitops-runtime-helm
 icon: https://avatars1.githubusercontent.com/u/11412079?v=3
 keywords:

--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -41,7 +41,7 @@ dependencies:
     condition: sealed-secrets.enabled
   - name: codefresh-tunnel-client
     repository: oci://quay.io/codefresh/charts
-    version: 0.1.24
+    version: 0.1.25
     alias: tunnel-client
     condition: tunnel-client.enabled
   - name: redis-ha

--- a/charts/gitops-runtime/README.md
+++ b/charts/gitops-runtime/README.md
@@ -748,7 +748,7 @@ global:
 | internal-router.fullnameOverride | string | `"internal-router"` |  |
 | internal-router.image.pullPolicy | string | `"IfNotPresent"` |  |
 | internal-router.image.repository | string | `"docker.io/nginxinc/nginx-unprivileged"` |  |
-| internal-router.image.tag | string | `"1.29-alpine3.23"` |  |
+| internal-router.image.tag | string | `"1.31.2-alpine3.23"` |  |
 | internal-router.imagePullSecrets | list | `[]` |  |
 | internal-router.ipv6 | object | `{"enabled":false}` | For ipv6 enabled clusters switch ipv6 enabled to true |
 | internal-router.nameOverride | string | `""` |  |

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -353,7 +353,7 @@ internal-router:
   image:
     repository: docker.io/nginxinc/nginx-unprivileged
     pullPolicy: IfNotPresent
-    tag: 1.29-alpine3.23
+    tag: 1.31.2-alpine3.23
   imagePullSecrets: []
   nameOverride: ""
   fullnameOverride: "internal-router"

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -748,7 +748,7 @@ redis-secret-init:
   image:
     registry: docker.io
     repository: alpine/kubectl
-    tag: 1.35.4
+    tag: 1.36.2
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## What

fix https://linear.app/octopus/issue/CFS-11626/security-or-alpinekubectl-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-11518/security-or-codefreshfrpc-or-cve-2026-45447-or

## Why

## Notes
<!-- Add any notes here -->