### PR TITLE
fix(cf-argocd-extras): security fix, bump image tag to c545381

### DIFF
--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -159,7 +159,7 @@ global:
     image:
       registry: quay.io
       repository: codefresh/cf-argocd-extras
-      tag: "621297b"
+      tag: "c545381"
     nodeSelector: {}
     tolerations: []
     affinity: {}
@@ -705,7 +705,7 @@ argo-gateway:
   image:
     registry: quay.io
     repository: codefresh/cf-argocd-extras
-    tag: "db849c5"
+    tag: "c545381"
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Why
https://linear.app/octopus/issue/CFS-13738/ready-for-release-codefreshcf-argocd-extrasc545381
## Notes
<!-- Add any notes here -->