### PR TITLE
fix(cf-argocd-extras): security fix, bump image tag to ace3860

### DIFF
--- a/charts/gitops-runtime/Chart.yaml
+++ b/charts/gitops-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.2.3
 description: A Helm chart for Codefresh gitops runtime
 name: gitops-runtime
-version: 0.29.16
+version: 0.29.17
 home: https://github.com/codefresh-io/gitops-runtime-helm
 icon: https://avatars1.githubusercontent.com/u/11412079?v=3
 keywords:

--- a/charts/gitops-runtime/values.yaml
+++ b/charts/gitops-runtime/values.yaml
@@ -159,7 +159,7 @@ global:
     image:
       registry: quay.io
       repository: codefresh/cf-argocd-extras
-      tag: "71b7e7c"
+      tag: "ace3860"
     nodeSelector: {}
     tolerations: []
     affinity: {}
@@ -705,7 +705,7 @@ argo-gateway:
   image:
     registry: quay.io
     repository: codefresh/cf-argocd-extras
-    tag: "3683869"
+    tag: "ace3860"
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Why
https://linear.app/octopus/issue/CFS-13738/ready-for-release-codefreshcf-argocd-extrasc545381
## Notes
<!-- Add any notes here -->